### PR TITLE
style: add prettier autoformats to eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['plugin:@typescript-eslint/recommended'],
+  extends: ['plugin:@typescript-eslint/recommended', 'prettier', 'plugin:prettier/recommended'],
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2018,
@@ -42,7 +42,8 @@ module.exports = {
     'max-depth': ['error', 4],
     'require-await': 'error',
     'space-before-function-paren': [
-      'error', {
+      'error',
+      {
         anonymous: 'never',
         named: 'never',
         asyncArrow: 'always',
@@ -63,7 +64,8 @@ module.exports = {
     '@typescript-eslint/no-useless-constructor': 'error',
     '@typescript-eslint/no-unused-expressions': 'error',
     '@typescript-eslint/member-delimiter-style': [
-      'error', {
+      'error',
+      {
         multiline: {
           delimiter: 'none',
           requireLast: true,
@@ -84,4 +86,4 @@ module.exports = {
       },
     },
   ],
-}
+};

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,10 +3,11 @@
   "tabWidth": 2,
   "useTabs": false,
   "bracketSpacing": true,
-  "quoteProps": "consistent",
   "semi": false,
   "singleQuote": true,
+  "quoteProps": "as-needed",
   "trailingComma": "all",
   "endOfLine": "lf",
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "proseWrap": "always"
 }


### PR DESCRIPTION
There were some problems with the eslint/prettier configuration, that prevented to do auto-formatting.
this PR solves this problem