### PR TITLE
feat: identity

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,10 +8,9 @@
         "request": "launch",
           "env": {
               "NODE_ENV": "development",
-              "BEE_URL": "http://localhost:1633"
+              "BEE_API_URL": "http://localhost:1633"
           }
       },
-
       {
         "name": "vscode-jest-tests",
         "program": "${workspaceFolder}/node_modules/.bin/jest",
@@ -19,7 +18,7 @@
         "request": "launch",
         "env": {
             "NODE_ENV": "development",
-            "BEE_URL": "http://localhost:1633"
+            "BEE_API_URL": "http://localhost:1633"
         },
         "args": [
           "--runInBand",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,5 +35,6 @@
     "**/coverage": true
   },
   "typescript.referencesCodeLens.enabled": true,
-  "jest.runAllTestsFirst": false
+  "jest.runAllTestsFirst": false,
+  "jest.autoEnable": false
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 > Command line interface tool for manage Bee node and utilize its functionalities
 
-The goal of this project to handle all Swarm related operations through CLI in the future.
+The goal of this project is to handle most of the Swarm operations through CLI at some point in the future.
 For currently supported operations, see [Commands](##Commands) section.
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The assigment priority how option gets its value in question is the following:
 With specific system environment variables you can alter the behaviour of the CLI
 
 * `BEE_API_URL` - API URL of Bee client
-* `SWARM_CLI_CONFIG_FOLDER` - full path of configuration folder
+* `SWARM_CLI_CONFIG_FOLDER` - full path to a configuration folder
 
 # Install
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ It is possible to set value of particular parameters in different ways.
 The assignment priority of how option gets its value in question is the following:
 
 1. passed CLI option value (with e.g. `--option-example-1`)
-2. env variable for that option in form of either `OPTION_EXAMPLE_1` or `SWARM_CLI_OPTION_EXAMPLE_1` (if it's available)
-3. CLI configuration value of that option (if it's available)
+2. env variable for that option in form of either `OPTION_EXAMPLE_1` or `SWARM_CLI_OPTION_EXAMPLE_1` (if it is available)
+3. CLI configuration value of that option (if it is available)
 4. option's default fallback value (or it is required to define by #1)
 
 ## System environment

--- a/README.md
+++ b/README.md
@@ -9,39 +9,87 @@
 ![](https://img.shields.io/badge/Node.js-%3E%3D10.0.0-orange.svg?style=flat-square)
 ![](https://img.shields.io/badge/runs%20in-browser%20%7C%20node%20%7C%20webworker%20%7C%20electron-orange)
 
-> Cli tool for manage Bee node and utilize its functionalities
-
 **Warning: This project is in alpha state. There might (and most probably will) be changes in the future to its API and working. Also, no guarantees can be made about its stability, efficiency, and security at this stage.**
 
-## Install
+# Description
 
-### npm
+> Command line interface tool for manage Bee node and utilize its functionalities
+
+The goal of this project to handle all Swarm related operations through CLI in the future.
+For currently supported operations, see [Commands](##Commands) section.
+
+## Commands
+
+`swarm-cli` can perform commands:
+- upload # upload files (even directories) to Swarm network by passing the file's path
+- identity # manage keys (which can be compatible with Ethereum V3 keystore standard) that you can use mostly for signing chunks
+
+for more info execute `swarm-cli --help` after installation.
+
+## Config
+
+The configuration file is placed in a hidden folder named swarm-cli.
+In case of Unix-based systems this config path will be: $HOME/.swarm-cli
+On Windows systems: $HOME\AppData\swarm-cli
+
+The configuration file is saved with 600 file permission.
+
+On first run, this configuration will be generated with default values, that you are able to change on your demand under the before mentioned path.
+
+## Assignment priority
+
+It is possible to set value of particular parameters in different ways.
+
+The assigment priority how option gets its value in question is the following:
+
+1. passed CLI option value (with e.g. `--option-example-1`)
+2. env variable for that option in form of either `OPTION_EXAMPLE_1` or `SWARM_CLI_OPTION_EXAMPLE_1` (if it's available)
+3. CLI configuration value of that option (if it's available)
+4. option's default fallback value (or it is required to define by #1)
+
+## System environment
+
+With specific system environment variables you can alter the behaviour of the CLI
+
+* `BEE_API_URL` - API URL of Bee client
+* `SWARM_CLI_CONFIG_FOLDER` - full path of configuration folder
+
+# Install
+
+## npm
 
 ```sh
-> npm install @ethersphere/swarm-cli
+ $ npm install -g @ethersphere/swarm-cli
 ```
 
-## Contribute
+# Compile code
+
+Install project dependencies with
+
+```sh
+ $ npm i
+```
+
+In order to compile NodeJS code run
+
+```sh
+ $ npm run compile
+```
+
+and you can try out the `swarm-cli` CLI after run command
+
+```sh
+ $ npm link
+```
+in your project folder.
+
+# Contribute
 
 There are some ways you can make this module better:
 
 - Consult our [open issues](https://github.com/ethersphere/swarm-cli/issues) and take on one of them
 - Help our tests reach 100% coverage!
 
-### Setup
-
-Install project dependencies with
-
-```sh
-npm i
-```
-
-### Compile code
-
-In order to compile NodeJS code run
-
-`npm run compile`
-
-## License
+# License
 
 [BSD-3-Clause](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ On first run, this configuration will be generated with default values, that you
 
 It is possible to set value of particular parameters in different ways.
 
-The assigment priority how option gets its value in question is the following:
+The assignment priority of how option gets its value in question is the following:
 
 1. passed CLI option value (with e.g. `--option-example-1`)
 2. env variable for that option in form of either `OPTION_EXAMPLE_1` or `SWARM_CLI_OPTION_EXAMPLE_1` (if it's available)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2144,6 +2144,14 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/cli-progress": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.8.0.tgz",
@@ -2152,6 +2160,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/configstore": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-4.0.0.tgz",
+      "integrity": "sha512-SvCBBPzOIe/3Tu7jTl2Q8NjITjLmq9m7obzjSyb8PXWWZ31xVK6w4T6v8fOx+lrgQnqk3Yxc00LDolFsSakKCA==",
+      "dev": true
     },
     "@types/eslint": {
       "version": "7.2.6",
@@ -2196,6 +2210,16 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/inquirer": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.1.tgz",
+      "integrity": "sha512-osD38QVIfcdgsPCT0V3lD7eH0OFurX71Jft18bZrsVQWVRt6TuxRzlr0GJLrxoHZR2V5ph7/qP8se/dcnI7o0g==",
+      "dev": true,
+      "requires": {
+        "@types/through": "*",
+        "rxjs": "^6.4.0"
       }
     },
     "@types/istanbul-lib-coverage": {
@@ -2253,8 +2277,7 @@
     "@types/node": {
       "version": "14.14.16",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.16.tgz",
-      "integrity": "sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw==",
-      "dev": true
+      "integrity": "sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -2268,11 +2291,27 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/pbkdf2": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/prettier": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.6.tgz",
       "integrity": "sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==",
       "dev": true
+    },
+    "@types/secp256k1": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
+      "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -2300,6 +2339,15 @@
       "requires": {
         "terser": "^5.3.8",
         "webpack": "^5.1.0"
+      }
+    },
+    "@types/through": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/uglify-js": {
@@ -2743,6 +2791,11 @@
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
     },
+    "aes-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2771,7 +2824,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-      "dev": true,
       "requires": {
         "type-fest": "^0.11.0"
       },
@@ -2779,8 +2831,7 @@
         "type-fest": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-          "dev": true
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
         }
       }
     },
@@ -3139,6 +3190,19 @@
         }
       }
     },
+    "base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -3153,6 +3217,38 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
+    },
+    "bl": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "blakejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+    },
+    "bn.js": {
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+      "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -3173,11 +3269,29 @@
         "fill-range": "^7.0.1"
       }
     },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
+    },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "browserslist": {
       "version": "4.16.0",
@@ -3192,6 +3306,24 @@
         "node-releases": "^1.1.67"
       }
     },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "requires": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -3201,11 +3333,25 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -3295,6 +3441,11 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
     "chrome-trace-event": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
@@ -3309,6 +3460,15 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "cjs-module-lexer": {
       "version": "0.6.0",
@@ -3339,6 +3499,14 @@
         }
       }
     },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
     "cli-progress": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.8.2.tgz",
@@ -3347,6 +3515,16 @@
         "colors": "^1.1.2",
         "string-width": "^4.2.0"
       }
+    },
+    "cli-spinners": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
+      "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ=="
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -3357,6 +3535,11 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
     "co": {
       "version": "4.6.0",
@@ -3549,6 +3732,31 @@
         "yaml": "^1.10.0"
       }
     },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -3671,6 +3879,14 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "^1.0.2"
+      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -3812,6 +4028,20 @@
       "integrity": "sha512-bsVCsONiVX1abkWdH7KtpuDAhsQ3N3bjPYhROSAXE78roJKet0Y5wznA14JE9pzbwSZmSMAW6KiKYf1RvbTJkA==",
       "dev": true
     },
+    "elliptic": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
     "emittery": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
@@ -3880,8 +4110,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.3",
@@ -4204,11 +4433,93 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "ethereum-cryptography": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "requires": {
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "ethereumjs-util": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.7.tgz",
+      "integrity": "sha512-vU5rtZBlZsgkTw3o6PDKyB8li2EgLavnAbsKcfsH2YhHH1Le+PP8vEiMnAnvgc1B6uMoaM5GDCrVztBw0Q5K9g==",
+      "requires": {
+        "@types/bn.js": "^4.11.3",
+        "bn.js": "^5.1.2",
+        "create-hash": "^1.1.2",
+        "ethereum-cryptography": "^0.1.3",
+        "ethjs-util": "0.1.6",
+        "rlp": "^2.2.4"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
+        }
+      }
+    },
+    "ethereumjs-wallet": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-1.0.1.tgz",
+      "integrity": "sha512-3Z5g1hG1das0JWU6cQ9HWWTY2nt9nXCcwj7eXVNAHKbo00XAZO8+NHlwdgXDWrL0SXVQMvTWN8Q/82DRH/JhPw==",
+      "requires": {
+        "aes-js": "^3.1.1",
+        "bs58check": "^2.1.2",
+        "ethereum-cryptography": "^0.1.3",
+        "ethereumjs-util": "^7.0.2",
+        "randombytes": "^2.0.6",
+        "scrypt-js": "^3.0.1",
+        "utf8": "^3.0.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
+    },
+    "ethjs-util": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+      "requires": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
+      }
+    },
     "events": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
       "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
       "dev": true
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -4356,6 +4667,16 @@
         }
       }
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -4487,6 +4808,14 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -4877,6 +5206,52 @@
         }
       }
     },
+    "hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
     "hosted-git-info": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
@@ -4991,10 +5366,14 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.1.8",
@@ -5055,14 +5434,78 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
+    },
+    "inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "interpret": {
       "version": "2.2.0",
@@ -5203,6 +5646,16 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-hex-prefixed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+    },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
     },
     "is-number": {
       "version": "7.0.0",
@@ -6819,6 +7272,15 @@
         "verror": "1.10.0"
       }
     },
+    "keccak": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+      "requires": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -6892,8 +7354,7 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -6924,6 +7385,59 @@
       "dev": true,
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
+      }
+    },
+    "log-symbols": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "requires": {
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "lru-cache": {
@@ -6986,6 +7500,16 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "meow": {
@@ -7053,14 +7577,23 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -7115,6 +7648,11 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -7151,6 +7689,16 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -7327,7 +7875,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -7357,6 +7904,71 @@
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
       }
+    },
+    "ora": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
+      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
+      "requires": {
+        "bl": "^4.0.3",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "log-symbols": "^4.0.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-each-series": {
       "version": "2.2.0",
@@ -7456,6 +8068,18 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
+    },
+    "pbkdf2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
     },
     "performance-now": {
       "version": "2.1.0",
@@ -7635,7 +8259,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -7972,6 +8595,15 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -7993,11 +8625,33 @@
         "glob": "^7.1.3"
       }
     },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "rlp": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+      "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
+      "requires": {
+        "bn.js": "^4.11.1"
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
+    },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
     },
     "run-parallel": {
       "version": "1.1.10",
@@ -8005,11 +8659,18 @@
       "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
+    "rxjs": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -8023,8 +8684,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -8269,6 +8929,21 @@
         "ajv-keywords": "^3.5.2"
       }
     },
+    "scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+    },
+    "secp256k1": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "requires": {
+        "elliptic": "^6.5.2",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -8325,6 +9000,20 @@
         }
       }
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -8350,8 +9039,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "sirv": {
       "version": "1.0.10",
@@ -8737,7 +9425,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -8767,6 +9454,14 @@
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
+    },
+    "strip-hex-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+      "requires": {
+        "is-hex-prefixed": "1.0.0"
+      }
     },
     "strip-indent": {
       "version": "3.0.0",
@@ -8941,8 +9636,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "4.0.2",
@@ -8964,6 +9658,14 @@
             "util-deprecate": "^1.0.1"
           }
         }
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tmpl": {
@@ -9074,8 +9776,7 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tsutils": {
       "version": "3.17.1",
@@ -9244,11 +9945,15 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "8.3.2",
@@ -9338,6 +10043,14 @@
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "requires": {
+        "defaults": "^1.0.3"
       }
     },
     "webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4978,9 +4978,9 @@
       "dev": true
     },
     "furious-commander": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/furious-commander/-/furious-commander-0.3.0.tgz",
-      "integrity": "sha512-pB8TJqFIXygtSOcSOKEONXuV3HrhlHrkoM10KZlyxbdapJMw8h2oR7KHaypowNVcoFSb0W+/lSoAMtUEAFFEVw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/furious-commander/-/furious-commander-0.4.0.tgz",
+      "integrity": "sha512-PL2gSoqfibUNP8MyOqunEQxdGo0nk9Dhdda7cKkPBdA7bWDgCpKQwXYGiM6n8E7+N4W15rGs8vveiWZCZ1cPRQ==",
       "requires": {
         "reflect-metadata": "^0.1.13",
         "yargs": "^16.2.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@types/cli-progress": "^3.8.0",
+    "@types/configstore": "^4.0.0",
     "@types/glob": "^7.1.3",
+    "@types/inquirer": "^7.3.1",
     "@types/jest": "^26.0.19",
     "@types/node": "^14.14.16",
     "@types/terser-webpack-plugin": "^5.0.2",
@@ -69,7 +71,10 @@
   },
   "dependencies": {
     "cli-progress": "^3.8.2",
+    "ethereumjs-wallet": "^1.0.1",
     "furious-commander": "^0.3.0",
-    "kleur": "^4.1.4"
+    "inquirer": "^7.3.3",
+    "kleur": "^4.1.4",
+    "ora": "^5.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "url": "https://github.com/ethersphere/swarm-cli.git"
   },
   "scripts": {
-    "compile": "webpack --progress --mode development",
+    "dev": "webpack --progress --env mode=development",
+    "compile": "webpack --progress --env mode=production",
     "test": "jest --config=jest.config.ts",
     "lint": "eslint --fix \"src/**/*.ts\" \"test/**/*.ts\" && prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:check": "eslint \"src/**/*.ts\" \"test/**/*.ts\" && prettier --check \"src/**/*.ts\" \"test/**/*.ts\""

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@ethersphere/bee-js": "^0.4.2",
     "cli-progress": "^3.8.2",
     "ethereumjs-wallet": "^1.0.1",
-    "furious-commander": "^0.3.0",
+    "furious-commander": "^0.4.0",
     "inquirer": "^7.3.3",
     "kleur": "^4.1.4",
     "ora": "^5.3.0"

--- a/src/command/identity/create.ts
+++ b/src/command/identity/create.ts
@@ -1,0 +1,83 @@
+import { LeafCommand, Argument, Option } from 'furious-commander'
+import { RootCommand } from '../root-command'
+import Wallet from 'ethereumjs-wallet'
+import { randomBytes } from 'crypto'
+import { bold, green, italic, red } from 'kleur'
+import { divider } from '../../utils/console-log'
+import { IdentityType, SimpleWallet, V3Keystore } from '../../service/identity/types'
+import { bytesToHex } from '../../utils/hex'
+import { exit } from 'process'
+import { askForPassword } from '../../utils/prompt'
+import ora from 'ora'
+
+export class Create extends RootCommand implements LeafCommand {
+  // CLI FIELDS
+
+  public readonly name = 'create'
+
+  public readonly description = 'Create Ethereum compatible keypair to sign chunks'
+
+  @Argument({ key: 'identity-name', default: 'main', describe: 'Reference name of the generated identity' })
+  public identityName!: string
+
+  @Option({ key: 'password', describe: 'Password for the wallet' })
+  public password!: string
+
+  @Option({
+    key: 'only-keypair',
+    type: 'boolean',
+    describe: 'Generate only the keypair for the identity. The private key will be stored cleartext. Fast to generate',
+  })
+  public onlyKeypair!: boolean
+
+  // CLASS FIELDS
+  public wallet!: Wallet
+
+  public async run(): Promise<void> {
+    this.initCommand()
+
+    //simple wallet
+    const privateKey = randomBytes(32)
+    this.wallet = new Wallet(privateKey)
+    let identityWallet: SimpleWallet | V3Keystore = { privateKey: bytesToHex(privateKey) }
+    let identityType: IdentityType = IdentityType.simple
+
+    //v3 wallet
+    if (!this.onlyKeypair) {
+      if (!this.password) {
+        console.log('You have not defined password with the "--password" option.')
+        console.log(italic('If you want to create disposable keypair, use "only-keypair" option'))
+        this.password = await askForPassword()
+      }
+      const spinner = ora('Creating V3 wallet...').start()
+      identityWallet = await this.wallet.toV3(this.password)
+      spinner.stop()
+      identityType = IdentityType.v3
+    }
+
+    //save into config
+    const successfulSave = this.commandConfig.saveIdentity(this.identityName, {
+      wallet: identityWallet,
+      identityType: identityType,
+    })
+
+    if (!successfulSave) {
+      console.warn(red(`Identity '${this.identityName}' already exist.`))
+
+      exit(1)
+    }
+
+    //print info
+    console.log('Keypair has been generated successfully!')
+    divider()
+    console.log(bold(`Identity name \t ${green(this.identityName)}`))
+    console.log(`Private key \t ${green(this.wallet.getPrivateKeyString())}`)
+    console.log(`Public key \t ${green(this.wallet.getPublicKeyString())}`)
+    console.log(`Address \t ${green(this.wallet.getAddressString())}`)
+  }
+
+  /** Init additional properties of class, that are not handled by the CLI framework */
+  private initCommand(): void {
+    super.init()
+  }
+}

--- a/src/command/identity/index.ts
+++ b/src/command/identity/index.ts
@@ -1,0 +1,12 @@
+import { GroupCommand } from 'furious-commander'
+import { Create } from './create'
+import { List } from './list'
+import { Remove } from './remove'
+
+export class Identity implements GroupCommand {
+  public readonly name = 'identity'
+
+  public readonly description = 'Keypair management interface'
+
+  public subCommandClasses = [Create, List, Remove]
+}

--- a/src/command/identity/list.ts
+++ b/src/command/identity/list.ts
@@ -1,0 +1,47 @@
+import { LeafCommand } from 'furious-commander'
+import { RootCommand } from '../root-command'
+import { bold, italic, red } from 'kleur'
+import { divider } from '../../utils/console-log'
+import { getPrintableIdentityType, getSimpleWallet, isSimleWallet, isV3Wallet } from '../../service/identity'
+
+export class List extends RootCommand implements LeafCommand {
+  // CLI FIELDS
+
+  public readonly name = 'list'
+
+  public readonly description = 'List keypairs which can be used to sign chunks'
+
+  public run(): void {
+    this.initCommand()
+
+    console.log('List of your identities')
+    divider('=')
+
+    if (!this.commandConfig.config.identities) {
+      console.log(red("You don't have any identity yet"))
+      console.log(italic(`You can create one with command '${this.appName} identity create'`))
+
+      return
+    }
+
+    for (const [identityName, identity] of Object.entries(this.commandConfig.config.identities)) {
+      console.log(bold(`Identity name \t ${identityName}`))
+      console.log(`Identity type \t ${getPrintableIdentityType(identity.identityType)}`)
+      const { wallet, identityType } = identity
+      let address = ''
+
+      if (isV3Wallet(wallet, identityType)) {
+        address = '0x' + wallet.address
+      } else if (isSimleWallet(wallet, identityType)) {
+        address = getSimpleWallet(wallet).getAddressString()
+      }
+      console.log(`Address \t ${address}`)
+      divider()
+    }
+  }
+
+  /** Init additional properties of class, that are not handled by the CLI framework */
+  private initCommand(): void {
+    super.init()
+  }
+}

--- a/src/command/identity/list.ts
+++ b/src/command/identity/list.ts
@@ -2,7 +2,7 @@ import { LeafCommand } from 'furious-commander'
 import { RootCommand } from '../root-command'
 import { bold, italic, red } from 'kleur'
 import { divider } from '../../utils/console-log'
-import { getPrintableIdentityType, getSimpleWallet, isSimleWallet, isV3Wallet } from '../../service/identity'
+import { getPrintableIdentityType, getSimpleWallet, isSimpleWallet, isV3Wallet } from '../../service/identity'
 
 export class List extends RootCommand implements LeafCommand {
   // CLI FIELDS
@@ -32,7 +32,7 @@ export class List extends RootCommand implements LeafCommand {
 
       if (isV3Wallet(wallet, identityType)) {
         address = '0x' + wallet.address
-      } else if (isSimleWallet(wallet, identityType)) {
+      } else if (isSimpleWallet(wallet, identityType)) {
         address = getSimpleWallet(wallet).getAddressString()
       }
       console.log(`Address \t ${address}`)

--- a/src/command/identity/remove.ts
+++ b/src/command/identity/remove.ts
@@ -1,0 +1,71 @@
+import { LeafCommand, Option, Argument } from 'furious-commander'
+import { RootCommand } from '../root-command'
+import { italic, red } from 'kleur'
+import inquirer from 'inquirer'
+import { exit } from 'process'
+
+export class Remove extends RootCommand implements LeafCommand {
+  // CLI FIELDS
+
+  public readonly name = 'remove'
+
+  public readonly description = 'Remove identity'
+
+  @Argument({ key: 'identity-name', describe: 'Name of the designated identity for delete' })
+  public identityName!: string
+
+  @Option({ key: 'force', alias: 'f', type: 'boolean', describe: 'Perform action without confirm input prompt' })
+  public force!: boolean
+
+  public async run(): Promise<void> {
+    this.initCommand()
+
+    if (!this.commandConfig.config.identities) {
+      console.log(red("You don't have any identity yet"))
+      console.log(italic(`You can create one with command '${this.appName} identity create'`))
+
+      return
+    }
+
+    const identityNames = Object.keys(this.commandConfig.config.identities)
+
+    if (!this.identityName) {
+      const identityNameChoice = await inquirer.prompt({
+        message: `Which identity that you would like to delete?`,
+        name: 'identityName',
+        choices: identityNames,
+        type: 'list',
+      })
+      this.identityName = identityNameChoice.identityName
+    }
+
+    //check identityName does exist
+    if (!identityNames.includes(this.identityName)) {
+      console.warn(red('Given identity name does not exist'))
+
+      return
+    }
+
+    if (!this.force) {
+      const approve = await inquirer.prompt({
+        type: 'confirm',
+        name: 'question',
+        message: `Are you sure you want delete identity '${this.identityName}'?`,
+      })
+
+      if (!approve.question) {
+        console.log('Removal of identity has been cancelled')
+
+        exit(1)
+      }
+    }
+
+    this.commandConfig.removeIdentity(this.identityName)
+    console.log('Identity has been successfully removed')
+  }
+
+  /** Init additional properties of class, that are not handled by the CLI framework */
+  private initCommand(): void {
+    super.init()
+  }
+}

--- a/src/command/root-command.ts
+++ b/src/command/root-command.ts
@@ -1,6 +1,8 @@
 import Bee from '@ethersphere/bee-js'
 import { ExternalOption } from 'furious-commander'
-import { defaultBeeApiUrl } from '../config'
+import { beeApiUrl } from '../config'
+import { IOption } from 'furious-commander/dist/option'
+import { CommandConfig } from './command-config'
 
 /**
  * This class can be parent of the Commands to handle root options of the CLI
@@ -12,9 +14,16 @@ export class RootCommand {
   @ExternalOption('bee-api-url')
   public beeApiUrl!: string
 
+  @ExternalOption('config-folder')
+  public configFolder!: string
+
   // CLASS FIELDS
 
+  public appName = 'swarm-cli'
+
   public bee!: Bee
+
+  public commandConfig!: CommandConfig
 
   /**
    * Init Root command fields
@@ -22,7 +31,14 @@ export class RootCommand {
    * if BEE_API_URL environment variable has been set the CLI will use that connection string
    */
   protected init(): void {
-    this.beeApiUrl = this.beeApiUrl === defaultBeeApiUrl ? process.env.BEE_API_URL || this.beeApiUrl : this.beeApiUrl
+    this.commandConfig = new CommandConfig(this.appName, this.configFolder)
+    this.beeApiUrl = this.optionPassed(beeApiUrl)
+      ? this.beeApiUrl
+      : this.commandConfig.config.beeApiUrl || process.env.BEE_API_URL || this.beeApiUrl
     this.bee = new Bee(this.beeApiUrl)
+  }
+
+  protected optionPassed(option: IOption): boolean {
+    return Boolean(process.argv.indexOf(`--${option.key}`) > -1)
   }
 }

--- a/src/command/root-command.ts
+++ b/src/command/root-command.ts
@@ -1,6 +1,6 @@
 import Bee from '@ethersphere/bee-js'
 import { ExternalOption } from 'furious-commander'
-import { beeApiUrl } from '../config'
+import { beeApiUrl, configFolder } from '../config'
 import { IOption } from 'furious-commander/dist/option'
 import { CommandConfig } from './command-config'
 
@@ -31,6 +31,9 @@ export class RootCommand {
    * if BEE_API_URL environment variable has been set the CLI will use that connection string
    */
   protected init(): void {
+    if (!this.optionPassed(configFolder)) {
+      if (process.env.SWARM_CLI_CONFIG_FOLDER) this.configFolder = process.env.SWARM_CLI_CONFIG_FOLDER
+    }
     this.commandConfig = new CommandConfig(this.appName, this.configFolder)
 
     if (!this.optionPassed(beeApiUrl)) {

--- a/src/command/root-command.ts
+++ b/src/command/root-command.ts
@@ -32,9 +32,12 @@ export class RootCommand {
    */
   protected init(): void {
     this.commandConfig = new CommandConfig(this.appName, this.configFolder)
-    this.beeApiUrl = this.optionPassed(beeApiUrl)
-      ? this.beeApiUrl
-      : this.commandConfig.config.beeApiUrl || process.env.BEE_API_URL || this.beeApiUrl
+
+    if (!this.optionPassed(beeApiUrl)) {
+      if (process.env.BEE_API_URL) this.beeApiUrl = process.env.BEE_API_URL
+      else if (this.commandConfig.config.beeApiUrl) this.beeApiUrl = this.commandConfig.config.beeApiUrl
+    } // else it gets its default option value
+
     this.bee = new Bee(this.beeApiUrl)
   }
 

--- a/src/command/root-command.ts
+++ b/src/command/root-command.ts
@@ -39,6 +39,6 @@ export class RootCommand {
   }
 
   protected optionPassed(option: IOption): boolean {
-    return Boolean(process.argv.indexOf(`--${option.key}`) > -1)
+    return process.argv.includes(`--${option.key}`)
   }
 }

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -6,6 +6,7 @@ import { sleep } from '../utils'
 import { Tag } from '@ethersphere/bee-js/dist/types'
 import { SingleBar, Presets } from 'cli-progress'
 import { bold, green, dim, red } from 'kleur'
+import { exit } from 'process'
 
 export class Upload extends RootCommand implements LeafCommand {
   // CLI FIELDS
@@ -54,7 +55,7 @@ export class Upload extends RootCommand implements LeafCommand {
     if (!FS.existsSync(this.path)) {
       console.warn(bold().red(`Given filepath '${this.path}' doesn't exist`))
 
-      return
+      exit(1)
     }
 
     if (FS.lstatSync(this.path).isDirectory()) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,18 @@
 import { IOption } from 'furious-commander/dist/option'
 import { Upload } from './command/upload'
+import { Identity } from './command/identity'
 
-export const defaultBeeApiUrl = 'http://localhost:1633'
+export const beeApiUrl: IOption<string> = {
+  key: 'bee-api-url',
+  default: 'http://localhost:1633',
+  describe: 'URL of the Bee-client API',
+} as const
 
-export const optionParameters: IOption<unknown>[] = [
-  { key: 'bee-api-url', default: defaultBeeApiUrl, describe: 'URL of the Bee-client API' },
-]
+export const configFolder: IOption<string> = {
+  key: 'config-folder',
+  describe: 'Path of the configuration files that the CLI uses',
+}
 
-export const rootCommandClasses = [Upload]
+export const optionParameters: IOption<unknown>[] = [beeApiUrl, configFolder]
+
+export const rootCommandClasses = [Upload, Identity]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
-import { cli } from 'furious-commander'
+import { cli, Utils } from 'furious-commander'
 import { rootCommandClasses, optionParameters } from './config'
+import PackageJson from '../package.json'
+
+Utils.yargs.version(PackageJson.version)
 
 cli({
   rootCommandClasses,

--- a/src/service/identity/index.ts
+++ b/src/service/identity/index.ts
@@ -1,0 +1,51 @@
+import Wallet from 'ethereumjs-wallet'
+import { hexToBytes } from '../../utils/hex'
+import { Identity, IdentityType, IdentityWallet, SimpleWallet, V3Keystore } from './types'
+
+export function getPrintableIdentityType(identityType: IdentityType): string {
+  switch (identityType) {
+    case IdentityType.simple:
+      return 'only keypair'
+    case IdentityType.v3:
+      return 'v3 keystore'
+    default:
+      throw new Error(`IdentityType '${identityType}' is not known.`)
+  }
+}
+
+export function isSimleWallet(wallet: IdentityWallet, identityType: IdentityType): wallet is SimpleWallet {
+  if (identityType === IdentityType.simple) return true
+
+  return false
+}
+
+export function isV3Wallet(wallet: IdentityWallet, identityType: IdentityType): wallet is V3Keystore {
+  if (identityType === IdentityType.v3) return true
+
+  return false
+}
+
+export function getSimpleWallet(wallet: SimpleWallet): Wallet {
+  const privateKeyBytes = hexToBytes(wallet.privateKey)
+
+  return new Wallet(Buffer.from(privateKeyBytes))
+}
+
+export function getV3Wallet(wallet: V3Keystore, password: string): Promise<Wallet> {
+  return Wallet.fromV3(wallet, password)
+}
+
+/** Used when identity's wallet is not sure which type */
+export function getWalletFromIdentity(identity: Identity, password?: string): Promise<Wallet> {
+  const { wallet, identityType } = identity
+
+  if (isSimleWallet(wallet, identityType)) {
+    return new Promise(resolve => resolve(getSimpleWallet(wallet)))
+  } else if (isV3Wallet(wallet, identityType)) {
+    if (!password) throw new Error(`There is no  password passed for V3 wallet initialization`)
+
+    return getV3Wallet(wallet, password)
+  }
+
+  throw new Error(`Wrong identity 'typeOfWallet' value: ${identity.identityType}`)
+}

--- a/src/service/identity/index.ts
+++ b/src/service/identity/index.ts
@@ -13,7 +13,7 @@ export function getPrintableIdentityType(identityType: IdentityType): string {
   }
 }
 
-export function isSimleWallet(wallet: IdentityWallet, identityType: IdentityType): wallet is SimpleWallet {
+export function isSimpleWallet(wallet: IdentityWallet, identityType: IdentityType): wallet is SimpleWallet {
   if (identityType === IdentityType.simple) return true
 
   return false
@@ -39,7 +39,7 @@ export function getV3Wallet(wallet: V3Keystore, password: string): Promise<Walle
 export function getWalletFromIdentity(identity: Identity, password?: string): Promise<Wallet> {
   const { wallet, identityType } = identity
 
-  if (isSimleWallet(wallet, identityType)) {
+  if (isSimpleWallet(wallet, identityType)) {
     return new Promise(resolve => resolve(getSimpleWallet(wallet)))
   } else if (isV3Wallet(wallet, identityType)) {
     if (!password) throw new Error(`There is no  password passed for V3 wallet initialization`)

--- a/src/service/identity/types/identity.ts
+++ b/src/service/identity/types/identity.ts
@@ -1,0 +1,15 @@
+import { V3Keystore, SimpleWallet } from './wallet'
+
+export type IdentityWallet = V3Keystore | SimpleWallet
+
+export enum IdentityType {
+  simple,
+  v3,
+}
+
+export interface Identity {
+  wallet: IdentityWallet
+  identityType: IdentityType
+}
+
+export const IdentityTypeArray = Object.values(IdentityType).filter(String)

--- a/src/service/identity/types/index.ts
+++ b/src/service/identity/types/index.ts
@@ -1,0 +1,2 @@
+export { V3Keystore, SimpleWallet } from './wallet'
+export { IdentityWallet, IdentityType, Identity, IdentityTypeArray } from './identity'

--- a/src/service/identity/types/wallet.ts
+++ b/src/service/identity/types/wallet.ts
@@ -1,0 +1,35 @@
+interface ScryptKDFParamsOut {
+  dklen: number
+  n: number
+  p: number
+  r: number
+  salt: string
+}
+
+interface PBKDFParamsOut {
+  c: number
+  dklen: number
+  prf: string
+  salt: string
+}
+declare type KDFParamsOut = ScryptKDFParamsOut | PBKDFParamsOut
+
+export interface V3Keystore {
+  crypto: {
+    cipher: string
+    cipherparams: {
+      iv: string
+    }
+    ciphertext: string
+    kdf: string
+    kdfparams: KDFParamsOut
+    mac: string
+  }
+  id: string
+  version: number
+  address?: string
+}
+
+export interface SimpleWallet {
+  privateKey: string
+}

--- a/src/utils/console-log.ts
+++ b/src/utils/console-log.ts
@@ -1,0 +1,4 @@
+/** Prints horizontal line */
+export function divider(char = '-'): void {
+  console.log(char.repeat(process.stdout.columns))
+}

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -1,0 +1,70 @@
+import { BrandedString } from '../types'
+
+/**
+ * Nominal type to represent hex strings
+ */
+export type HexString = BrandedString<'HexString'>
+
+/**
+ * Strips the '0x' hex prefix from a string
+
+ * @param hex string input
+ */
+export function stripHexPrefix<T extends string>(hex: T): T {
+  return hex.startsWith('0x') ? (hex.slice(2) as T) : hex
+}
+
+/**
+ * Converts a hex string to Uint8Array
+ *
+ * @param hex string input
+ */
+export function hexToBytes(hex: string): Uint8Array {
+  const hexWithoutPrefix = stripHexPrefix(hex)
+  const bytes = new Uint8Array(hexWithoutPrefix.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    const hexByte = hexWithoutPrefix.substr(i * 2, 2)
+    bytes[i] = parseInt(hexByte, 16)
+  }
+
+  return bytes
+}
+
+/**
+ * Converts array of number or Uint8Array to hex string.
+ *
+ * Optionally provides a the '0x' prefix.
+ *
+ * @param bytes       The input array
+ * @param withPrefix  Provides '0x' prefix when true (default: false)
+ */
+export function bytesToHex(bytes: Uint8Array, withPrefix = false): HexString {
+  const prefix = withPrefix ? '0x' : ''
+  const hexByte = (n: number) => n.toString(16).padStart(2, '0')
+  const hex = Array.from(bytes, hexByte).join('')
+
+  return `${prefix}${hex}` as HexString
+}
+
+/**
+ * Type guard for HexStrings
+ *
+ * @param s string input
+ */
+export function isHexString(s: string): s is HexString {
+  return /^(0x)?[0-9a-fA-F]+$/i.test(s)
+}
+
+/**
+ * Verifies if the provided input is a HexString.
+ *
+ * @param s string input
+ *
+ * @returns HexString or throws error
+ */
+export function verifyHex(s: string): HexString | never {
+  if (isHexString(s)) {
+    return s
+  }
+  throw new Error(`verifyHex: not valid hex string: ${s}`)
+}

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -1,4 +1,4 @@
-import { BrandedString } from '../types'
+import { BrandedString } from './types'
 
 /**
  * Nominal type to represent hex strings

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,0 +1,38 @@
+// General prompts
+
+import { prompt } from 'inquirer'
+import { red } from 'kleur'
+import { exit } from 'process'
+
+/**
+ * Ask for password
+ *
+ * @returns password
+ */
+export async function askForPassword(): Promise<string> {
+  const passwordInput = await prompt({
+    type: 'password',
+    name: 'question',
+    message: `Please provide a password`,
+  })
+  const password = passwordInput.question
+
+  if (!password) {
+    console.warn(red('You did not pass any password'))
+
+    exit(1)
+  }
+  const passwordInputAgain = await prompt({
+    type: 'password',
+    name: 'question',
+    message: `Please repeat the previously typed password`,
+  })
+
+  if (passwordInputAgain.question !== password) {
+    console.warn(red('The two passwords do not match'))
+
+    exit(1)
+  }
+
+  return password
+}

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -1,0 +1,10 @@
+/**
+ * These type are used to create new nominal types
+ *
+ * See https://spin.atomicobject.com/2018/01/15/typescript-flexible-nominal-typing/
+ */
+export type BrandedType<T, N> = T & { __tag__: N }
+
+export type BrandedString<N> = BrandedType<string, N>
+
+export type FlavoredType<T, N> = T & { __tag__?: N }

--- a/test/command/identity.spec.ts
+++ b/test/command/identity.spec.ts
@@ -1,0 +1,99 @@
+import { rootCommandClasses, optionParameters } from '../../src/config'
+import { cli, Utils } from 'furious-commander'
+import { join } from 'path'
+import { access, unlinkSync, existsSync } from 'fs'
+import { promisify } from 'util'
+import { List } from '../../src/command/identity/list'
+
+describe('Test Identity command', () => {
+  const commandKey = 'identity'
+  const configFolderPath = join(__dirname, '..', 'testconfig')
+  const configFilePath = join(configFolderPath, 'config.json')
+  const existFile = promisify(access)
+  let consoleMessages: string[] = []
+
+  beforeAll(() => {
+    global.console.log = jest.fn(message => {
+      consoleMessages.push(message)
+    })
+    jest.spyOn(global.console, 'warn')
+    //set config environment variable
+    process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
+
+    //remove config file if it exists
+    if (existsSync(configFilePath)) unlinkSync(configFilePath)
+  })
+
+  beforeEach(() => {
+    //clear stored console messages
+    consoleMessages = []
+  })
+
+  it('should create default config on the first run', async () => {
+    await cli({
+      rootCommandClasses,
+      optionParameters,
+      testArguments: [commandKey, 'list'],
+    })
+    expect(await existFile(configFilePath)).toBeUndefined()
+  })
+
+  it('should create V3 identity "main"', async () => {
+    const walletPassword = '123'
+
+    // create identity
+    await cli({
+      rootCommandClasses,
+      optionParameters,
+      testArguments: [commandKey, 'create', '--password', walletPassword],
+    })
+    expect(consoleMessages[0]).toBe('Keypair has been generated successfully!')
+  })
+
+  it('should create simple identity "temporary-identity"', async () => {
+    // create identity
+    await cli({
+      rootCommandClasses,
+      optionParameters,
+      testArguments: [commandKey, 'create', 'temporary-identity', '--only-keypair'],
+    })
+    expect(consoleMessages[0]).toBe('Keypair has been generated successfully!')
+  })
+
+  it('should list already created identities', async () => {
+    // create identity
+    const commandBuilder = await cli({
+      rootCommandClasses,
+      optionParameters,
+      testArguments: [commandKey, 'list'],
+    })
+    expect(consoleMessages[0]).toBe('List of your identities')
+    expect(consoleMessages[2].includes('Identity name') && consoleMessages[2].includes('main')).toBeTruthy()
+    expect(
+      consoleMessages[6].includes('Identity name') && consoleMessages[6].includes('temporary-identity'),
+    ).toBeTruthy()
+    const listCommand = Utils.getCommandInstance(commandBuilder.initedCommands, ['identity', 'list']) as List
+    expect(Object.keys(listCommand.commandConfig.config.identities).length).toBe(2)
+    expect(listCommand.commandConfig.config.identities.main).toBeDefined()
+    expect(listCommand.commandConfig.config.identities['temporary-identity']).toBeDefined()
+  })
+
+  it('should remove identity "temporary-identity"', async () => {
+    // remove identity
+    await cli({
+      rootCommandClasses,
+      optionParameters,
+      testArguments: [commandKey, 'remove', 'temporary-identity', '-f'],
+    })
+    expect(consoleMessages[0]).toBe('Identity has been successfully removed')
+    // check it removed from the identity list
+    const commandBuilder = await cli({
+      rootCommandClasses,
+      optionParameters,
+      testArguments: [commandKey, 'list'],
+    })
+    const listCommand = Utils.getCommandInstance(commandBuilder.initedCommands, ['identity', 'list']) as List
+    expect(Object.keys(listCommand.commandConfig.config.identities).length).toBe(1)
+    expect(listCommand.commandConfig.config.identities['temporary-identity']).toBeUndefined()
+  })
+})

--- a/test/testconfig/.gitignore
+++ b/test/testconfig/.gitignore
@@ -1,0 +1,2 @@
+# ignore config used at tests
+config.json

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -97,6 +97,7 @@ const base = (env?: Partial<WebpackEnvParams>): Configuration => {
     performance: {
       hints: false,
     },
+    watch: !isProduction,
   }
 }
 


### PR DESCRIPTION
# Description
This PR adds `identity` commands to the CLI.
It handles wallets of the user, which will be mostly used for sign chunks.

Config feature also has been added, in order to store wallets on the user's computer.
The configuration file is placed in a hidden folder named `swarm-cli`.
In case of Unix-based systems this config path will be: `$HOME/.swarm-cli`
On Windows systems: `$HOME\AppData\swarm-cli`

The configuration file is saved with 600 file permission.

There are two types of wallets currently in this feat PR: `simple` and `V3 keystore`.
- The first only generates a private key, that it will store in the config fire in cleartext. These can be generated quickly.
- The latter is Ethereum compatible wallet, which fits to the `V3` standard. Its creation is slower and also requires a password.


If wallet import functionality is needed directly, (because it is possible now, by altering the just mentioned config file) please describe your idea below.

## TODO
- [x] Write tests
- [ ] Add import possibility 
- [x] Review README
- [x] Add `bee-js` dependency