### PR TITLE
ci: release on github and npmjs

### DIFF
--- a/.github/workflows/publish_npmjs.yaml
+++ b/.github/workflows/publish_npmjs.yaml
@@ -1,0 +1,20 @@
+# After new release is published on github, publish it to npmjs
+name: Publish on npmjs
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release_github.yaml
+++ b/.github/workflows/release_github.yaml
@@ -1,0 +1,19 @@
+# On each new commit to master, create/update a PR with release
+# automatically bumps version and creates changelog as per conventional commits
+name: Release Github
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        id: release
+        with:
+          token: ${{ secrets.REPO_GHA_PAT }}
+          release-type: node
+          package-name: bee-js

--- a/.github/workflows/release_github.yaml
+++ b/.github/workflows/release_github.yaml
@@ -16,4 +16,4 @@ jobs:
         with:
           token: ${{ secrets.REPO_GHA_PAT }}
           release-type: node
-          package-name: bee-js
+          package-name: swarm-cli

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/ethersphere/swarm-cli.git"
   },
   "scripts": {
+    "prepare": "npm run compile",
     "compile": "webpack --progress --mode development",
     "test": "jest --config=jest.config.ts",
     "lint": "eslint --fix \"src/**/*.ts\" \"test/**/*.ts\" && prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",


### PR DESCRIPTION
For more info and how to use please see https://github.com/ethersphere/bee-js/pull/70

## TODO: 
- [x] test on personal fork of the repo (see [Github Action](https://github.com/vojtechsimetka/swarm-cli/runs/1816306410) and [npm package](https://www.npmjs.com/package/@vojtechsimetka/swarm-cli) )
- [x] verify npmjs token is set (@vandot ?)
- [x] verify github PAT is set (@vandot ?)