### PR TITLE
fix: handle not found and bad request pinning errors

### DIFF
--- a/src/command/pinning/pin.ts
+++ b/src/command/pinning/pin.ts
@@ -21,7 +21,7 @@ export class Pin extends RootCommand implements LeafCommand {
       this.console.error('Could not pin ' + this.address)
 
       if (error.message === 'Not Found') {
-        this.console.error('No root chunks found with that address.')
+        this.console.error('No root chunk found with that address.')
       } else if (error.message === 'Internal Server Error') {
         this.console.error(
           'Pinning root chunks which were uploaded with --index-document header are currently not supported.',

--- a/src/command/pinning/pin.ts
+++ b/src/command/pinning/pin.ts
@@ -18,8 +18,11 @@ export class Pin extends RootCommand implements LeafCommand {
       await this.bee.pinCollection(this.address)
       this.console.log('Pinned successfully')
     } catch (error) {
-      if (error.message === 'Internal Server Error') {
-        this.console.error('Could not pin ' + this.address)
+      this.console.error('Could not pin ' + this.address)
+
+      if (error.message === 'Not Found') {
+        this.console.error('No root chunks found with that address.')
+      } else if (error.message === 'Internal Server Error') {
         this.console.error(
           'Pinning root chunks which were uploaded with --index-document header are currently not supported.',
         )

--- a/src/command/pinning/unpin.ts
+++ b/src/command/pinning/unpin.ts
@@ -18,12 +18,12 @@ export class Unpin extends RootCommand implements LeafCommand {
       await this.bee.unpinCollection(this.address)
       this.console.log('Unpinned successfully')
     } catch (error) {
-      if (error.message === 'Internal Server Error') {
-        this.console.error('Could not unpin ' + this.address)
-        this.console.error('This chunk may not be pinned. Please verify with the command `pinning list`.')
-        this.console.error(
-          'Unpinning root chunks which were uploaded with --index-document header are currently not supported.',
-        )
+      this.console.error('Could not unpin ' + this.address)
+
+      if (error.message === 'Bad Request') {
+        this.console.error('Only root chunks can be unpinned.')
+      } else if (error.message === 'Not Found') {
+        this.console.error('No pinned chunks found with that address.')
       } else {
         this.console.error(error.message)
       }

--- a/src/command/pinning/unpin.ts
+++ b/src/command/pinning/unpin.ts
@@ -23,7 +23,7 @@ export class Unpin extends RootCommand implements LeafCommand {
       if (error.message === 'Bad Request') {
         this.console.error('Only root chunks can be unpinned.')
       } else if (error.message === 'Not Found') {
-        this.console.error('No pinned chunks found with that address.')
+        this.console.error('No pinned chunk found with that address.')
       } else {
         this.console.error(error.message)
       }

--- a/test/command/pinning.spec.ts
+++ b/test/command/pinning.spec.ts
@@ -110,4 +110,17 @@ describe('Test Pinning command', () => {
     const countOfItemsAfter = consoleMessages.length
     expect(countOfItemsAfter).toBeLessThan(countOfItemsBefore)
   })
+
+  it('should print custom 404 when unpinning chunk that does not exist', async () => {
+    await cli({
+      rootCommandClasses,
+      optionParameters,
+      testArguments: ['pinning', 'unpin', 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'],
+    })
+    expect(consoleMessages).toHaveLength(2)
+    expect(consoleMessages[0]).toContain(
+      'Could not unpin ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+    )
+    expect(consoleMessages[1]).toContain('No pinned chunks found with that address.')
+  })
 })

--- a/test/command/pinning.spec.ts
+++ b/test/command/pinning.spec.ts
@@ -121,7 +121,7 @@ describe('Test Pinning command', () => {
     expect(consoleMessages[0]).toContain(
       'Could not pin ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
     )
-    expect(consoleMessages[1]).toContain('No root chunks found with that address.')
+    expect(consoleMessages[1]).toContain('No root chunk found with that address.')
   })
 
   it('should print custom 404 when unpinning chunk that does not exist', async () => {
@@ -134,6 +134,6 @@ describe('Test Pinning command', () => {
     expect(consoleMessages[0]).toContain(
       'Could not unpin ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
     )
-    expect(consoleMessages[1]).toContain('No pinned chunks found with that address.')
+    expect(consoleMessages[1]).toContain('No pinned chunk found with that address.')
   })
 })

--- a/test/command/pinning.spec.ts
+++ b/test/command/pinning.spec.ts
@@ -111,6 +111,19 @@ describe('Test Pinning command', () => {
     expect(countOfItemsAfter).toBeLessThan(countOfItemsBefore)
   })
 
+  it('should print custom 404 when pinning chunk that does not exist', async () => {
+    await cli({
+      rootCommandClasses,
+      optionParameters,
+      testArguments: ['pinning', 'pin', 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'],
+    })
+    expect(consoleMessages).toHaveLength(2)
+    expect(consoleMessages[0]).toContain(
+      'Could not pin ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+    )
+    expect(consoleMessages[1]).toContain('No root chunks found with that address.')
+  })
+
   it('should print custom 404 when unpinning chunk that does not exist', async () => {
     await cli({
       rootCommandClasses,


### PR DESCRIPTION
Checking for `Internal Server Error` during `pinning unpin` was a mistake originally. It either returns `Not Found` or `Bad Request`. This PR handles these cases with a nicer error message and adds a test case for that.

In `pinning pin`, `Internal Server Error` is correct, but the `Not Found` case also exists there which was not handled. This PR also adds that with a test.