### PR TITLE
fix: remove --minimum option where it makes no sense

### DIFF
--- a/src/command/cheque/cashout.ts
+++ b/src/command/cheque/cashout.ts
@@ -18,6 +18,9 @@ export class Cashout extends ChequeCommand implements LeafCommand {
   @Option({ key: 'all', alias: 'a', type: 'boolean', describe: 'Cashout all cheques', default: false })
   public all!: boolean
 
+  @Option({ key: 'minimum', alias: 'm', type: 'number', describe: 'Filter based on minimum balance', default: 1 })
+  public minimum = 1
+
   public async run(): Promise<void> {
     super.init()
 

--- a/src/command/cheque/cheque-command.ts
+++ b/src/command/cheque/cheque-command.ts
@@ -1,4 +1,3 @@
-import { Option } from 'furious-commander'
 import { bold, dim, italic } from 'kleur'
 import { RootCommand } from '../root-command'
 
@@ -8,9 +7,6 @@ interface Cashable {
 }
 
 export class ChequeCommand extends RootCommand {
-  @Option({ key: 'minimum', alias: 'm', type: 'number', describe: 'Filter based on minimum balance', default: 1 })
-  public minimum = 1
-
   protected async checkDebugApiHealth(): Promise<boolean> {
     try {
       this.console.verbose(italic(dim('Checking Debug API health...')))

--- a/src/command/cheque/list.ts
+++ b/src/command/cheque/list.ts
@@ -1,4 +1,4 @@
-import { LeafCommand } from 'furious-commander'
+import { LeafCommand, Option } from 'furious-commander'
 import { ChequeCommand } from './cheque-command'
 
 export class List extends ChequeCommand implements LeafCommand {
@@ -9,6 +9,9 @@ export class List extends ChequeCommand implements LeafCommand {
   public readonly aliases = ['ls']
 
   public readonly description = 'List cashable cheques'
+
+  @Option({ key: 'minimum', alias: 'm', type: 'number', describe: 'Filter based on minimum balance', default: 1 })
+  public minimum = 1
 
   public async run(): Promise<void> {
     super.init()


### PR DESCRIPTION
Some `cheque` commands inherited the `--minimum` option.

Examples:

```
balance
withdraw
deposit
```

It is only used in:

```
cashout
list
```
