### PR TITLE
docs: unify group descriptions

### DIFF
--- a/src/command/cheque/index.ts
+++ b/src/command/cheque/index.ts
@@ -8,7 +8,7 @@ import { Withdraw } from './withdraw'
 export class Cheque implements GroupCommand {
   public readonly name = 'cheque'
 
-  public readonly description = 'Cheque'
+  public readonly description = 'Deposit, withdraw and manage cheques'
 
   public subCommandClasses = [List, Cashout, Balance, Deposit, Withdraw]
 }

--- a/src/command/feed/index.ts
+++ b/src/command/feed/index.ts
@@ -6,7 +6,7 @@ import { Upload } from './upload'
 export class Feed implements GroupCommand {
   public readonly name = 'feed'
 
-  public readonly description = 'Feed utilities'
+  public readonly description = 'Upload, update and view feeds'
 
   public subCommandClasses = [Update, Upload, Print]
 }

--- a/src/command/identity/index.ts
+++ b/src/command/identity/index.ts
@@ -8,7 +8,7 @@ import { Remove } from './remove'
 export class Identity implements GroupCommand {
   public readonly name = 'identity'
 
-  public readonly description = 'Keypair management interface'
+  public readonly description = 'Import, export and manage keypairs, identities'
 
   public subCommandClasses = [Create, List, Remove, Import, Export]
 }

--- a/src/command/pinning/index.ts
+++ b/src/command/pinning/index.ts
@@ -6,7 +6,7 @@ import { Unpin } from './unpin'
 export class Pinning implements GroupCommand {
   public readonly name = 'pinning'
 
-  public readonly description = 'Pinning utilities'
+  public readonly description = 'Pin, unpin and check pinned chunks'
 
   public subCommandClasses = [Pin, Unpin, List]
 }


### PR DESCRIPTION
The goal here is to provide a bit nicer descriptions to command groups. Instead of simply saying _utilities_ or _interface_, or printing only _Cheque_, try to write a few examples with better wording.

Before

```
index.js pinning        - Pinning utilities
index.js identity       - Keypair management interface
index.js feed           - Feed utilities
index.js cheque         - Cheque
```

After

```
pinning    Pin, unpin and check pinned chunks
identity   Import, export and manage keypairs, identities
feed       Upload, update and view feeds
cheque     Deposit, withdraw and manage cheques
```