### PR TITLE
refactor: extract printing functions to avoid instantiation

### DIFF
--- a/src/command/root-command/command-log.ts
+++ b/src/command/root-command/command-log.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { prompt } from 'inquirer'
 import { exit } from 'process'
 import { Printer } from './printer'

--- a/src/command/root-command/command-log.ts
+++ b/src/command/root-command/command-log.ts
@@ -46,8 +46,8 @@ export class CommandLog {
         this.verbose = Printer.emptyFunction
         this.log = Printer.log
         this.info = Printer.info
-        this.divider = Printer.divider
         this.dim = Printer.emptyFunction
+        this.divider = Printer.divider
         break
       default:
         // quiet

--- a/src/command/root-command/command-log.ts
+++ b/src/command/root-command/command-log.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { prompt } from 'inquirer'
-import { bold, dim, italic } from 'kleur'
 import { exit } from 'process'
+import { Printer } from './printer'
 
 export enum VerbosityLevel {
   /** No output message, only at errors or result strings (e.g. hash of uploaded file) */
@@ -31,45 +31,34 @@ export class CommandLog {
   public divider: (char?: string) => void
 
   constructor(verbosityLevel: VerbosityLevel) {
-    const emptyFunction = () => {
-      return
-    }
-    const divider = (char = '-') => {
-      console.log(char.repeat(process.stdout.columns))
-    }
-    const error = (message: string, ...args: unknown[]) => console.log(bold().white().bgRed(message), ...args)
-    const log = (message: string, ...args: unknown[]) => console.log(message, ...args)
-    const info = (message: string, ...args: unknown[]) => console.log(italic().dim(message), ...args)
-    const dimFunction = (message: string, ...args: unknown[]) => console.log(dim(message), ...args)
-
     switch (verbosityLevel) {
       case VerbosityLevel.Verbose:
-        this.error = error
-        this.quiet = emptyFunction
-        this.verbose = log
-        this.log = log
-        this.info = info
-        this.dim = dimFunction
-        this.divider = divider
+        this.error = Printer.error
+        this.quiet = Printer.emptyFunction
+        this.verbose = Printer.log
+        this.log = Printer.log
+        this.info = Printer.info
+        this.dim = Printer.dimFunction
+        this.divider = Printer.divider
         break
       case VerbosityLevel.Normal:
-        this.error = error
-        this.quiet = emptyFunction
-        this.verbose = emptyFunction
-        this.log = log
-        this.info = info
-        this.divider = divider
-        this.dim = emptyFunction
+        this.error = Printer.error
+        this.quiet = Printer.emptyFunction
+        this.verbose = Printer.emptyFunction
+        this.log = Printer.log
+        this.info = Printer.info
+        this.divider = Printer.divider
+        this.dim = Printer.emptyFunction
         break
       default:
         // quiet
-        this.error = error
-        this.quiet = log
-        this.verbose = emptyFunction
-        this.log = emptyFunction
-        this.info = emptyFunction
-        this.dim = emptyFunction
-        this.divider = emptyFunction
+        this.error = Printer.error
+        this.quiet = Printer.log
+        this.verbose = Printer.emptyFunction
+        this.log = Printer.emptyFunction
+        this.info = Printer.emptyFunction
+        this.dim = Printer.emptyFunction
+        this.divider = Printer.emptyFunction
     }
   }
 

--- a/src/command/root-command/printer.ts
+++ b/src/command/root-command/printer.ts
@@ -1,0 +1,23 @@
+/* eslint-disable no-console */
+import { bold, dim, italic } from 'kleur'
+
+export const Printer = {
+  emptyFunction: (): void => {
+    return
+  },
+  divider: (char = '-'): void => {
+    console.log(char.repeat(process.stdout.columns))
+  },
+  error: (message: string, ...args: unknown[]): void => {
+    console.log(bold().white().bgRed(message), ...args)
+  },
+  log: (message: string, ...args: unknown[]): void => {
+    console.log(message, ...args)
+  },
+  info: (message: string, ...args: unknown[]): void => {
+    console.log(italic().dim(message), ...args)
+  },
+  dimFunction: (message: string, ...args: unknown[]): void => {
+    console.log(dim(message), ...args)
+  },
+}

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,13 +1,11 @@
 import { Printer } from 'furious-commander/dist/printer'
 import { bold, dim } from 'kleur'
-import { CommandLog, VerbosityLevel } from './command/root-command/command-log'
-
-const commandLog = new CommandLog(VerbosityLevel.Normal)
+import { Printer as SwarmPrinter } from './command/root-command/printer'
 
 export const printer: Printer = {
-  print: commandLog.log,
-  printError: commandLog.error,
-  printHeading: (text: string) => commandLog.log(bold('█ ' + text)),
+  print: SwarmPrinter.log,
+  printError: SwarmPrinter.error,
+  printHeading: (text: string) => SwarmPrinter.log(bold('█ ' + text)),
   formatDim: (text: string) => dim(text),
   formatImportant: (text: string) => bold(text),
   getGenericErrorMessage: () => 'Failed to run command!',


### PR DESCRIPTION
Continuation of https://github.com/ethersphere/swarm-cli/pull/79#discussion_r623905757

This PR extracts the different `console.log` printing methods so they can be used without instantiation.

They are used to construct `CommandLog` as well as `Printer` for furious-commander.