### PR TITLE
refactor: simplify reading config via sourcemap

### DIFF
--- a/src/command/root-command/command-config.ts
+++ b/src/command/root-command/command-config.ts
@@ -7,6 +7,13 @@ import { Identity } from '../../service/identity/types'
 import { ConfigOption } from '../../utils/types/config-option'
 import { CommandLog } from './command-log'
 
+/**
+ * Options listed here will be read from the config file
+ * when they are not set explicitly or via `process.env`.
+ *
+ * `optionKey` is the kebab-case variant of the argument used in the parser, a.k.a. the key,
+ * `propertyKey` is the camelCase variant used in TypeScript command classes, a.k.a. the property.
+ */
 export const CONFIG_OPTIONS: ConfigOption[] = [
   { optionKey: 'bee-api-url', propertyKey: 'beeApiUrl' },
   { optionKey: 'bee-debug-api-url', propertyKey: 'beeDebugApiUrl' },

--- a/src/command/root-command/command-config.ts
+++ b/src/command/root-command/command-config.ts
@@ -6,7 +6,15 @@ import { beeApiUrl, beeDebugApiUrl } from '../../config'
 import { Identity } from '../../service/identity/types'
 import { CommandLog } from './command-log'
 
-export const CONFIG_KEYS = ['beeApiUrl', 'beeDebugApiUrl']
+export interface ConfigOption {
+  optionKey: string
+  propertyKey: string
+}
+
+export const CONFIG_OPTIONS: ConfigOption[] = [
+  { optionKey: 'bee-api-url', propertyKey: 'beeApiUrl' },
+  { optionKey: 'bee-debug-api-url', propertyKey: 'beeDebugApiUrl' },
+]
 
 export interface Config {
   beeApiUrl: string

--- a/src/command/root-command/command-config.ts
+++ b/src/command/root-command/command-config.ts
@@ -36,7 +36,7 @@ export class CommandConfig {
 
   public console: CommandLog
 
-  constructor(appName: string, console: CommandLog, configFolder?: string) {
+  constructor(appName: string, console: CommandLog, configFile: string, configFolder?: string) {
     this.console = console
     this.config = {
       beeApiUrl: beeApiUrl.default || '',
@@ -44,7 +44,7 @@ export class CommandConfig {
       identities: {},
     }
     this.configFolderPath = this.getConfigFolderPath(appName, configFolder)
-    this.configFilePath = join(this.configFolderPath, process.env.SWARM_CLI_CONFIG_FILE || 'config.json')
+    this.configFilePath = join(this.configFolderPath, configFile)
     this.prepareConfig()
   }
 

--- a/src/command/root-command/command-config.ts
+++ b/src/command/root-command/command-config.ts
@@ -6,6 +6,8 @@ import { beeApiUrl, beeDebugApiUrl } from '../../config'
 import { Identity } from '../../service/identity/types'
 import { CommandLog } from './command-log'
 
+export const CONFIG_KEYS = ['beeApiUrl', 'beeDebugApiUrl']
+
 export interface Config {
   beeApiUrl: string
 

--- a/src/command/root-command/command-config.ts
+++ b/src/command/root-command/command-config.ts
@@ -4,12 +4,8 @@ import { join } from 'path'
 import { exit } from 'process'
 import { beeApiUrl, beeDebugApiUrl } from '../../config'
 import { Identity } from '../../service/identity/types'
+import { ConfigOption } from '../../utils/types/config-option'
 import { CommandLog } from './command-log'
-
-export interface ConfigOption {
-  optionKey: string
-  propertyKey: string
-}
 
 export const CONFIG_OPTIONS: ConfigOption[] = [
   { optionKey: 'bee-api-url', propertyKey: 'beeApiUrl' },

--- a/src/command/root-command/index.ts
+++ b/src/command/root-command/index.ts
@@ -1,6 +1,6 @@
 import { Bee, BeeDebug } from '@ethersphere/bee-js'
 import { ExternalOption, Sourcemap, Utils } from 'furious-commander'
-import { CommandConfig, CONFIG_KEYS } from './command-config'
+import { CommandConfig, ConfigOption, CONFIG_OPTIONS } from './command-config'
 import { CommandLog, VerbosityLevel } from './command-log'
 
 export class RootCommand {
@@ -34,7 +34,9 @@ export class RootCommand {
     this.commandConfig = new CommandConfig(this.appName, this.console, this.configFolder)
     this.sourcemap = Utils.getSourcemap()
 
-    CONFIG_KEYS.forEach(key => this.maybeSetFromConfig(key))
+    CONFIG_OPTIONS.forEach((option: ConfigOption) => {
+      this.maybeSetFromConfig(option)
+    })
 
     this.bee = new Bee(this.beeApiUrl)
     this.beeDebug = new BeeDebug(this.beeDebugApiUrl)
@@ -48,12 +50,12 @@ export class RootCommand {
     this.console = new CommandLog(this.verbosity)
   }
 
-  private maybeSetFromConfig(key: string): void {
-    if (this.sourcemap[key] === 'default') {
-      const value = Reflect.get(this.commandConfig.config, key)
+  private maybeSetFromConfig(option: ConfigOption): void {
+    if (this.sourcemap[option.optionKey] === 'default') {
+      const value = Reflect.get(this.commandConfig.config, option.propertyKey)
 
       if (value !== undefined) {
-        Reflect.set(this, key, value)
+        Reflect.set(this, option.propertyKey, value)
       }
     }
   }

--- a/src/command/root-command/index.ts
+++ b/src/command/root-command/index.ts
@@ -1,6 +1,6 @@
 import { Bee, BeeDebug } from '@ethersphere/bee-js'
 import { ExternalOption, Sourcemap, Utils } from 'furious-commander'
-import { CommandConfig, ConfigOption, CONFIG_OPTIONS } from './command-config'
+import { CommandConfig, Config, ConfigOption, CONFIG_OPTIONS } from './command-config'
 import { CommandLog, VerbosityLevel } from './command-log'
 
 export class RootCommand {
@@ -52,10 +52,11 @@ export class RootCommand {
 
   private maybeSetFromConfig(option: ConfigOption): void {
     if (this.sourcemap[option.optionKey] === 'default') {
-      const value = Reflect.get(this.commandConfig.config, option.propertyKey)
+      const key = option.propertyKey as keyof Config & keyof RootCommand
+      const value = this.commandConfig.config[key]
 
       if (value !== undefined) {
-        Reflect.set(this, option.propertyKey, value)
+        this[key] = value
       }
     }
   }

--- a/src/command/root-command/index.ts
+++ b/src/command/root-command/index.ts
@@ -14,6 +14,9 @@ export class RootCommand {
   @ExternalOption('config-folder')
   public configFolder!: string
 
+  @ExternalOption('config-file')
+  public configFile!: string
+
   @ExternalOption('verbosity')
   public verbosity!: VerbosityLevel
 
@@ -32,7 +35,7 @@ export class RootCommand {
   private sourcemap!: Sourcemap
 
   protected init(): void {
-    this.commandConfig = new CommandConfig(this.appName, this.console, this.configFolder)
+    this.commandConfig = new CommandConfig(this.appName, this.console, this.configFile, this.configFolder)
     this.sourcemap = Utils.getSourcemap()
 
     CONFIG_OPTIONS.forEach((option: ConfigOption) => {

--- a/src/command/root-command/index.ts
+++ b/src/command/root-command/index.ts
@@ -34,7 +34,7 @@ export class RootCommand {
     this.commandConfig = new CommandConfig(this.appName, this.console, this.configFolder)
     this.sourcemap = Utils.getSourcemap()
 
-    CONFIG_KEYS.forEach(this.maybeSetFromConfig)
+    CONFIG_KEYS.forEach(key => this.maybeSetFromConfig(key))
 
     this.bee = new Bee(this.beeApiUrl)
     this.beeDebug = new BeeDebug(this.beeDebugApiUrl)

--- a/src/command/root-command/index.ts
+++ b/src/command/root-command/index.ts
@@ -1,6 +1,7 @@
 import { Bee, BeeDebug } from '@ethersphere/bee-js'
 import { ExternalOption, Sourcemap, Utils } from 'furious-commander'
-import { CommandConfig, Config, ConfigOption, CONFIG_OPTIONS } from './command-config'
+import { ConfigOption } from '../../utils/types/config-option'
+import { CommandConfig, CONFIG_OPTIONS } from './command-config'
 import { CommandLog, VerbosityLevel } from './command-log'
 
 export class RootCommand {
@@ -52,11 +53,10 @@ export class RootCommand {
 
   private maybeSetFromConfig(option: ConfigOption): void {
     if (this.sourcemap[option.optionKey] === 'default') {
-      const key = option.propertyKey as keyof Config & keyof RootCommand
-      const value = this.commandConfig.config[key]
+      const value = this.commandConfig.config[option.propertyKey]
 
       if (value !== undefined) {
-        this[key] = value
+        this[option.propertyKey] = value
       }
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,8 +23,15 @@ export const beeDebugApiUrl: IOption<string> = {
 
 export const configFolder: IOption<string> = {
   key: 'config-folder',
-  description: 'Path of the configuration files that the CLI uses',
+  description: 'Path to the configuration folder that the CLI uses',
   envKey: 'SWARM_CLI_CONFIG_FOLDER',
+}
+
+export const configFile: IOption<string> = {
+  key: 'config-file',
+  description: 'Name of the configuration file that the CLI uses',
+  envKey: 'SWARM_CLI_CONFIG_FILE',
+  default: 'config.json',
 }
 
 export const verbose: IOption<boolean> = {
@@ -66,6 +73,7 @@ export const optionParameters: IOption<unknown>[] = [
   beeApiUrl,
   beeDebugApiUrl,
   configFolder,
+  configFile,
   verbose,
   quiet,
   help,

--- a/src/utils/types/config-option.ts
+++ b/src/utils/types/config-option.ts
@@ -1,0 +1,7 @@
+import { RootCommand } from '../../command/root-command'
+import { Config } from '../../command/root-command/command-config'
+
+export interface ConfigOption {
+  optionKey: string
+  propertyKey: keyof Config & keyof RootCommand
+}

--- a/test/command/config.spec.ts
+++ b/test/command/config.spec.ts
@@ -42,7 +42,7 @@ describe('Test configuration loading', () => {
     expect(consoleMessages[0]).toContain('http://localhost:30003')
   })
 
-  it('should use env it is not specified', async () => {
+  it('should use env over config when specified', async () => {
     process.env.BEE_DEBUG_API_URL = 'http://localhost:30002'
 
     await cli({

--- a/test/command/config.spec.ts
+++ b/test/command/config.spec.ts
@@ -18,8 +18,6 @@ describe('Test configuration loading', () => {
     //set config environment variable
     process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
     process.env.SWARM_CLI_CONFIG_FILE = configFileName
-
-    //remove config file if it exists
   })
 
   beforeEach(() => {

--- a/test/command/config.spec.ts
+++ b/test/command/config.spec.ts
@@ -1,0 +1,64 @@
+import { writeFileSync } from 'fs'
+import cli from 'furious-commander'
+import { join } from 'path'
+import { optionParameters, rootCommandClasses } from '../../src/config'
+
+describe('Test configuration loading', () => {
+  let consoleMessages: string[] = []
+
+  const configFolderPath = join(__dirname, '..', 'testconfig')
+  const configFileName = 'config.config.json'
+  const configFilePath = join(configFolderPath, configFileName)
+
+  beforeAll(() => {
+    global.console.log = jest.fn(message => {
+      consoleMessages.push(message)
+    })
+    jest.spyOn(global.console, 'warn')
+    //set config environment variable
+    process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
+    process.env.SWARM_CLI_CONFIG_FILE = configFileName
+
+    //remove config file if it exists
+  })
+
+  beforeEach(() => {
+    //clear stored console messages
+    consoleMessages = []
+  })
+
+  it('should use config when env is not specified', async () => {
+    writeFileSync(
+      configFilePath,
+      JSON.stringify({
+        beeDebugApiUrl: 'http://localhost:30003',
+      }),
+    )
+    await cli({
+      rootCommandClasses,
+      optionParameters,
+      testArguments: ['cheque', 'list'],
+    })
+    expect(consoleMessages[0]).toContain('http://localhost:30003')
+  })
+
+  it('should use env it is not specified', async () => {
+    process.env.BEE_DEBUG_API_URL = 'http://localhost:30002'
+
+    await cli({
+      rootCommandClasses,
+      optionParameters,
+      testArguments: ['cheque', 'list'],
+    })
+    expect(consoleMessages[0]).toContain('http://localhost:30002')
+  })
+
+  it('should use explicit option over all', async () => {
+    await cli({
+      rootCommandClasses,
+      optionParameters,
+      testArguments: ['cheque', 'list', '--bee-debug-api-url', 'http://localhost:30001'],
+    })
+    expect(consoleMessages[0]).toContain('http://localhost:30001')
+  })
+})

--- a/test/misc/config.spec.ts
+++ b/test/misc/config.spec.ts
@@ -13,7 +13,9 @@ describe('Test configuration loading', () => {
     global.console.log = jest.fn(message => {
       consoleMessages.push(message)
     })
-    jest.spyOn(global.console, 'warn')
+    global.console.error = jest.fn(message => {
+      consoleMessages.push(message)
+    })
     //set config environment variable
     process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
     process.env.SWARM_CLI_CONFIG_FILE = configFileName
@@ -32,19 +34,19 @@ describe('Test configuration loading', () => {
       }),
     )
 
-    await invokeTestCli(['cheque', 'list', '-q'])
+    await invokeTestCli(['cheque', 'list'])
     expect(consoleMessages[0]).toContain('http://localhost:30003')
   })
 
   it('should use env over config when specified', async () => {
     process.env.BEE_DEBUG_API_URL = 'http://localhost:30002'
 
-    await invokeTestCli(['cheque', 'list', '-q'])
+    await invokeTestCli(['cheque', 'list'])
     expect(consoleMessages[0]).toContain('http://localhost:30002')
   })
 
   it('should use explicit option over all', async () => {
-    await invokeTestCli(['cheque', 'list', '--bee-debug-api-url', 'http://localhost:30001', '-q'])
+    await invokeTestCli(['cheque', 'list', '--bee-debug-api-url', 'http://localhost:30001'])
     expect(consoleMessages[0]).toContain('http://localhost:30001')
   })
 })

--- a/test/misc/config.spec.ts
+++ b/test/misc/config.spec.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync } from 'fs'
-import { join, parse } from 'path'
+import { writeFileSync } from 'fs'
+import { join } from 'path'
 import { invokeTestCli } from '../utility'
 
 describe('Test configuration loading', () => {
@@ -27,6 +27,8 @@ describe('Test configuration loading', () => {
   })
 
   it('should use config when env is not specified', async () => {
+    delete process.env.BEE_DEBUG_API_URL
+
     writeFileSync(
       configFilePath,
       JSON.stringify({
@@ -34,22 +36,8 @@ describe('Test configuration loading', () => {
       }),
     )
 
-    const parsedPath = parse(configFilePath)
-
-    process.env.SWARM_CLI_CONFIG_FOLDER = parsedPath.dir
-    process.env.SWARM_CLI_CONFIG_FILE = parsedPath.base
-
     await invokeTestCli(['cheque', 'list'])
-    expect(consoleMessages[0]).toContain(
-      'http://localhost:30003 ' +
-        JSON.stringify(parsedPath) +
-        ' ' +
-        process.env.SWARM_CLI_CONFIG_FOLDER +
-        ' ' +
-        process.env.SWARM_CLI_CONFIG_FILE +
-        ' ' +
-        readFileSync(configFilePath, 'utf-8'),
-    )
+    expect(consoleMessages[0]).toContain('http://localhost:30003')
   })
 
   it('should use env over config when specified', async () => {

--- a/test/misc/config.spec.ts
+++ b/test/misc/config.spec.ts
@@ -1,5 +1,5 @@
 import { writeFileSync } from 'fs'
-import { join } from 'path'
+import { join, parse } from 'path'
 import { invokeTestCli } from '../utility'
 
 describe('Test configuration loading', () => {
@@ -34,6 +34,11 @@ describe('Test configuration loading', () => {
       }),
     )
 
+    const parsedPath = parse(configFilePath)
+
+    process.env.SWARM_CLI_CONFIG_FOLDER = parsedPath.dir
+    process.env.SWARM_CLI_CONFIG_FILE = parsedPath.base
+
     await invokeTestCli(['cheque', 'list'])
     expect(consoleMessages[0]).toContain('http://localhost:30003')
   })
@@ -62,10 +67,5 @@ describe('Test configuration loading', () => {
 
     await invokeTestCli(['cheque', 'list', '--config-file', 'config2.config.json'])
     expect(consoleMessages[0]).toContain('http://localhost:30004')
-  })
-
-  it('should raise error when receiving invalid configuration folder', async () => {
-    await invokeTestCli(['cheque', 'list', '--config-folder', '/no/such'])
-    expect(consoleMessages[2]).toContain("ENOENT: no such file or directory, mkdir '/no/such'")
   })
 })

--- a/test/misc/config.spec.ts
+++ b/test/misc/config.spec.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'fs'
+import { readFileSync, writeFileSync } from 'fs'
 import { join, parse } from 'path'
 import { invokeTestCli } from '../utility'
 
@@ -40,7 +40,16 @@ describe('Test configuration loading', () => {
     process.env.SWARM_CLI_CONFIG_FILE = parsedPath.base
 
     await invokeTestCli(['cheque', 'list'])
-    expect(consoleMessages[0]).toContain('http://localhost:30003 ' + JSON.stringify(parsedPath))
+    expect(consoleMessages[0]).toContain(
+      'http://localhost:30003 ' +
+        JSON.stringify(parsedPath) +
+        ' ' +
+        process.env.SWARM_CLI_CONFIG_FOLDER +
+        ' ' +
+        process.env.SWARM_CLI_CONFIG_FILE +
+        ' ' +
+        readFileSync(configFilePath, 'utf-8'),
+    )
   })
 
   it('should use env over config when specified', async () => {

--- a/test/misc/config.spec.ts
+++ b/test/misc/config.spec.ts
@@ -13,6 +13,9 @@ describe('Test configuration loading', () => {
     global.console.log = jest.fn(message => {
       consoleMessages.push(message)
     })
+    global.console.error = jest.fn(message => {
+      consoleMessages.push(message)
+    })
     //set config environment variable
     process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
     process.env.SWARM_CLI_CONFIG_FILE = configFileName
@@ -59,5 +62,10 @@ describe('Test configuration loading', () => {
 
     await invokeTestCli(['cheque', 'list', '--config-file', 'config2.config.json'])
     expect(consoleMessages[0]).toContain('http://localhost:30004')
+  })
+
+  it('should raise error when receiving invalid configuration folder', async () => {
+    await invokeTestCli(['cheque', 'list', '--config-folder', '/no/such'])
+    expect(consoleMessages[2]).toContain("ENOENT: no such file or directory, mkdir '/no/such'")
   })
 })

--- a/test/misc/config.spec.ts
+++ b/test/misc/config.spec.ts
@@ -13,9 +13,6 @@ describe('Test configuration loading', () => {
     global.console.log = jest.fn(message => {
       consoleMessages.push(message)
     })
-    global.console.error = jest.fn(message => {
-      consoleMessages.push(message)
-    })
     //set config environment variable
     process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
     process.env.SWARM_CLI_CONFIG_FILE = configFileName
@@ -48,5 +45,19 @@ describe('Test configuration loading', () => {
   it('should use explicit option over all', async () => {
     await invokeTestCli(['cheque', 'list', '--bee-debug-api-url', 'http://localhost:30001'])
     expect(consoleMessages[0]).toContain('http://localhost:30001')
+  })
+
+  it('should read config path explicitly, then use it for url', async () => {
+    delete process.env.BEE_DEBUG_API_URL
+
+    writeFileSync(
+      join(configFolderPath, 'config2.config.json'),
+      JSON.stringify({
+        beeDebugApiUrl: 'http://localhost:30004',
+      }),
+    )
+
+    await invokeTestCli(['cheque', 'list', '--config-file', 'config2.config.json'])
+    expect(consoleMessages[0]).toContain('http://localhost:30004')
   })
 })

--- a/test/misc/config.spec.ts
+++ b/test/misc/config.spec.ts
@@ -32,19 +32,19 @@ describe('Test configuration loading', () => {
       }),
     )
 
-    await invokeTestCli(['cheque', 'list'])
+    await invokeTestCli(['cheque', 'list', '-q'])
     expect(consoleMessages[0]).toContain('http://localhost:30003')
   })
 
   it('should use env over config when specified', async () => {
     process.env.BEE_DEBUG_API_URL = 'http://localhost:30002'
 
-    await invokeTestCli(['cheque', 'list'])
+    await invokeTestCli(['cheque', 'list', '-q'])
     expect(consoleMessages[0]).toContain('http://localhost:30002')
   })
 
   it('should use explicit option over all', async () => {
-    await invokeTestCli(['cheque', 'list', '--bee-debug-api-url', 'http://localhost:30001'])
+    await invokeTestCli(['cheque', 'list', '--bee-debug-api-url', 'http://localhost:30001', '-q'])
     expect(consoleMessages[0]).toContain('http://localhost:30001')
   })
 })

--- a/test/misc/config.spec.ts
+++ b/test/misc/config.spec.ts
@@ -40,7 +40,7 @@ describe('Test configuration loading', () => {
     process.env.SWARM_CLI_CONFIG_FILE = parsedPath.base
 
     await invokeTestCli(['cheque', 'list'])
-    expect(consoleMessages[0]).toContain('http://localhost:30003')
+    expect(consoleMessages[0]).toContain('http://localhost:30003 ' + JSON.stringify(parsedPath))
   })
 
   it('should use env over config when specified', async () => {

--- a/test/misc/config.spec.ts
+++ b/test/misc/config.spec.ts
@@ -1,7 +1,6 @@
 import { writeFileSync } from 'fs'
-import cli from 'furious-commander'
 import { join } from 'path'
-import { optionParameters, rootCommandClasses } from '../../src/config'
+import { invokeTestCli } from '../utility'
 
 describe('Test configuration loading', () => {
   let consoleMessages: string[] = []
@@ -32,31 +31,20 @@ describe('Test configuration loading', () => {
         beeDebugApiUrl: 'http://localhost:30003',
       }),
     )
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['cheque', 'list'],
-    })
+
+    await invokeTestCli(['cheque', 'list'])
     expect(consoleMessages[0]).toContain('http://localhost:30003')
   })
 
   it('should use env over config when specified', async () => {
     process.env.BEE_DEBUG_API_URL = 'http://localhost:30002'
 
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['cheque', 'list'],
-    })
+    await invokeTestCli(['cheque', 'list'])
     expect(consoleMessages[0]).toContain('http://localhost:30002')
   })
 
   it('should use explicit option over all', async () => {
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['cheque', 'list', '--bee-debug-api-url', 'http://localhost:30001'],
-    })
+    await invokeTestCli(['cheque', 'list', '--bee-debug-api-url', 'http://localhost:30001'])
     expect(consoleMessages[0]).toContain('http://localhost:30001')
   })
 })


### PR DESCRIPTION
Continuation of https://github.com/ethersphere/swarm-cli/pull/79#discussion_r623898323

Instead of having duplicated `if` blocks for each option that may be specified via the swarm-cli config file, we just have to maintain an array: `CONFIG_OPTIONS`.