### PR TITLE
ci: bee factory parameters

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,6 @@ on:
       - '**'
 
 env:
-  BEE_VERSION: '0.6.0-17f7837-dirty'
-  BLOCKCHAIN_VERSION: '1.1.0'
   BEE_ENV_PREFIX: 'swarm-test'
   BEE_IMAGE_PREFIX: 'docker.pkg.github.com/ethersphere/bee-factory'
   COMMIT_VERSION_TAG: 'false'


### PR DESCRIPTION
from now `BEE_VERSION` and `BLOCKCHAIN_VERSION` Bee Factory parameters in CI will use the [.env](https://github.com/ethersphere/bee-factory/blob/master/scripts/.env) definitions according to the chosen branch.