### PR TITLE
ci: bee factory parameters

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ on:
       - '**'
 
 env:
+  BEE_VERSION: '0.6.0-c1e87ce-dirty'
+  BLOCKCHAIN_VERSION: '1.1.1'
   BEE_ENV_PREFIX: 'swarm-test'
   BEE_IMAGE_PREFIX: 'docker.pkg.github.com/ethersphere/bee-factory'
   COMMIT_VERSION_TAG: 'false'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,6 @@ on:
       - '**'
 
 env:
-  BEE_VERSION: '0.6.0-17f7837-dirty'
-  BLOCKCHAIN_VERSION: '1.1.0'
   BEE_ENV_PREFIX: 'swarm-test'
   BEE_IMAGE_PREFIX: 'docker.pkg.github.com/ethersphere/bee-factory'
   COMMIT_VERSION_TAG: 'false'


### PR DESCRIPTION
for current 0.6.0 compatbility the CI will update its env parameters to the followings:
- BEE_VERSION="0.6.0-c1e87ce-dirty" 
- BLOCKCHAIN_VERSION="1.1.1"