### PR TITLE
refactor(test): shorten cli calls

### DIFF
--- a/test/command/feed.spec.ts
+++ b/test/command/feed.spec.ts
@@ -1,9 +1,8 @@
 import { existsSync, unlinkSync } from 'fs'
-import { cli } from 'furious-commander'
 import { join } from 'path'
 import { Create } from '../../src/command/identity/create'
 import { Upload } from '../../src/command/upload'
-import { optionParameters, rootCommandClasses } from '../../src/config'
+import { invokeTestCli } from '../utility'
 import { getStampOption } from '../utility/stamp'
 
 describe('Test Feed command', () => {
@@ -32,118 +31,82 @@ describe('Test Feed command', () => {
 
   it('should upload file, update feed and print it', async () => {
     // create identity
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['identity', 'create', 'test', '--password', 'test'],
-    })
+    await invokeTestCli(['identity', 'create', 'test', '--password', 'test'])
     // upload
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: [
-        'feed',
-        'upload',
-        `${__dirname}/../testpage/images/swarm.png`,
-        '--identity',
-        'test',
-        '--topic',
-        'test',
-        '--password',
-        'test',
-        '--hash-topic',
-        '--quiet',
-        ...getStampOption(),
-      ],
-    })
+    await invokeTestCli([
+      'feed',
+      'upload',
+      `${__dirname}/../testpage/images/swarm.png`,
+      '--identity',
+      'test',
+      '--topic',
+      'test',
+      '--password',
+      'test',
+      '--hash-topic',
+      '--quiet',
+      ...getStampOption(),
+    ])
     // print with identity and password
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: [
-        'feed',
-        'print',
-        '--identity',
-        'test',
-        '--topic',
-        'test',
-        '--password',
-        'test',
-        '--hash-topic',
-        '--quiet',
-        ...getStampOption(),
-      ],
-    })
+    await invokeTestCli([
+      'feed',
+      'print',
+      '--identity',
+      'test',
+      '--topic',
+      'test',
+      '--password',
+      'test',
+      '--hash-topic',
+      '--quiet',
+      ...getStampOption(),
+    ])
     const length = consoleMessages.length
     expect(consoleMessages[length - 1]).toMatch(/[a-z0-9]{64}/)
   })
 
   it('should print feed using address only', async () => {
     // create identity
-    const commandBuilder = await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['identity', 'create', 'test2', '--password', 'test'],
-    })
+    const commandBuilder = await invokeTestCli(['identity', 'create', 'test2', '--password', 'test'])
     const identityCreate = commandBuilder.runnable as Create
     const address = identityCreate.wallet.getAddressString()
     // upload
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: [
-        'feed',
-        'upload',
-        `${__dirname}/../testpage/index.html`,
-        '--identity',
-        'test2',
-        '--password',
-        'test',
-        ...getStampOption(),
-      ],
-    })
+    await invokeTestCli([
+      'feed',
+      'upload',
+      `${__dirname}/../testpage/index.html`,
+      '--identity',
+      'test2',
+      '--password',
+      'test',
+      ...getStampOption(),
+    ])
     // print with address
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['feed', 'print', '--address', address, '--quiet', ...getStampOption()],
-    })
+    await invokeTestCli(['feed', 'print', '--address', address, '--quiet', ...getStampOption()])
     const length = consoleMessages.length
     expect(consoleMessages[length - 1]).toMatch(/[a-z0-9]{64}/)
   })
 
   it('should update feeds', async () => {
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['identity', 'create', 'update-feed-test', '-P', '1234', '-v'],
-    })
-    const uploadCommand = await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['upload', 'README.md', '--skip-sync', ...getStampOption()],
-    })
+    await invokeTestCli(['identity', 'create', 'update-feed-test', '-P', '1234', '-v'])
+    const uploadCommand = await invokeTestCli(['upload', 'README.md', '--skip-sync', ...getStampOption()])
     const upload = uploadCommand.runnable as Upload
     const { hash } = upload
     consoleMessages = []
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: [
-        'feed',
-        'update',
-        '--topic',
-        'test-topic',
-        '--hash-topic',
-        '-i',
-        'update-feed-test',
-        '-P',
-        '1234',
-        '-r',
-        hash,
-        ...getStampOption(),
-      ],
-    })
+    await invokeTestCli([
+      'feed',
+      'update',
+      '--topic',
+      'test-topic',
+      '--hash-topic',
+      '-i',
+      'update-feed-test',
+      '-P',
+      '1234',
+      '-r',
+      hash,
+      ...getStampOption(),
+    ])
     expect(consoleMessages).toHaveLength(1)
     expect(consoleMessages[0]).toContain('Feed Manifest URL')
     expect(consoleMessages[0]).toContain('/bzz/')

--- a/test/command/identity.spec.ts
+++ b/test/command/identity.spec.ts
@@ -1,10 +1,9 @@
 import Wallet from 'ethereumjs-wallet'
 import { access, existsSync, unlinkSync, writeFileSync } from 'fs'
-import { cli } from 'furious-commander'
 import { join } from 'path'
 import { promisify } from 'util'
 import { List } from '../../src/command/identity/list'
-import { optionParameters, rootCommandClasses } from '../../src/config'
+import { invokeTestCli } from '../utility'
 
 describe('Test Identity command', () => {
   const configFolderPath = join(__dirname, '..', 'testconfig')
@@ -30,41 +29,25 @@ describe('Test Identity command', () => {
   })
 
   it('should create default config on the first run', async () => {
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['identity', 'list'],
-    })
+    await invokeTestCli(['identity', 'list'])
     expect(await existFile(configFilePath)).toBeUndefined()
   })
 
   it('should create V3 identity "main"', async () => {
     // create identity
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['identity', 'create', '--password', '1234'],
-    })
+    await invokeTestCli(['identity', 'create', '--password', '1234'])
     expect(consoleMessages[0]).toBe('Keypair has been generated successfully!')
   })
 
   it('should create simple identity "temporary-identity"', async () => {
     // create identity
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['identity', 'create', 'temporary-identity', '--only-keypair'],
-    })
+    await invokeTestCli(['identity', 'create', 'temporary-identity', '--only-keypair'])
     expect(consoleMessages[0]).toBe('Keypair has been generated successfully!')
   })
 
   it('should list already created identities', async () => {
     // create identity
-    const commandBuilder = await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['identity', 'list'],
-    })
+    const commandBuilder = await invokeTestCli(['identity', 'list'])
     expect(consoleMessages[0]).toContain('List of your identities')
     expect(consoleMessages[2]).toContain('Identity name')
     expect(consoleMessages[2]).toContain('main')
@@ -78,18 +61,10 @@ describe('Test Identity command', () => {
 
   it('should remove identity "temporary-identity"', async () => {
     // remove identity
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['identity', 'remove', 'temporary-identity', '-f'],
-    })
+    await invokeTestCli(['identity', 'remove', 'temporary-identity', '-f'])
     expect(consoleMessages[0]).toBe('Identity has been successfully removed')
     // check it removed from the identity list
-    const commandBuilder = await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['identity', 'list'],
-    })
+    const commandBuilder = await invokeTestCli(['identity', 'list'])
     const listCommand = commandBuilder.runnable as List
     expect(Object.keys(listCommand.commandConfig.config.identities)).toHaveLength(1)
     expect(listCommand.commandConfig.config.identities['temporary-identity']).toBeUndefined()
@@ -97,17 +72,9 @@ describe('Test Identity command', () => {
 
   it('should export v3 identity', async () => {
     // first create a v3 identity
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['identity', 'create', 'v3-identity', '--password', 'test'],
-    })
+    await invokeTestCli(['identity', 'create', 'v3-identity', '--password', 'test'])
     // then export it
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['identity', 'export', 'v3-identity'],
-    })
+    await invokeTestCli(['identity', 'export', 'v3-identity'])
     // and check if the last console message looked like a v3 wallet json
     const exportIndex = consoleMessages.length - 1
     expect(consoleMessages[exportIndex]).toContain('"ciphertext"')
@@ -120,11 +87,7 @@ describe('Test Identity command', () => {
     const path = join(configFolderPath, 'v3-keystore.json')
     writeFileSync(path, v3string)
     // then import it
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['identity', 'import', path, '--identity-name', 'import-test', '--password', '123'],
-    })
+    await invokeTestCli(['identity', 'import', path, '--identity-name', 'import-test', '--password', '123'])
     // and check for successful import message
     const successfulImportIndex = consoleMessages.length - 1
     expect(consoleMessages[successfulImportIndex]).toContain(

--- a/test/command/stamp.spec.ts
+++ b/test/command/stamp.spec.ts
@@ -1,5 +1,4 @@
-import { cli } from 'furious-commander'
-import { optionParameters, rootCommandClasses } from '../../src/config'
+import { invokeTestCli } from '../utility'
 
 describe('Test Stamp command', () => {
   const consoleMessages: string[] = []
@@ -19,41 +18,25 @@ describe('Test Stamp command', () => {
   })
 
   it('should list stamps', async () => {
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['stamp', 'list'],
-    })
+    await invokeTestCli(['stamp', 'list'])
     expect(consoleMessages[1]).toContain('Stamp ID:')
     expect(consoleMessages[2]).toContain('Utilization:')
   })
 
   it('should show a specific stamp', async () => {
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['stamp', 'show', process.env.STAMP || ''],
-    })
+    await invokeTestCli(['stamp', 'show', process.env.STAMP || ''])
     expect(consoleMessages[1]).toContain('Stamp ID:')
     expect(consoleMessages[1]).toContain(process.env.STAMP)
     expect(consoleMessages[2]).toContain('Utilization:')
   })
 
   it('should not allow buying stamp with amount 0', async () => {
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['stamp', 'buy', '--amount', '0', '--depth', '20'],
-    })
+    await invokeTestCli(['stamp', 'buy', '--amount', '0', '--depth', '20'])
     expect(getLastMessage()).toContain('[amount] must be at least 1')
   })
 
   it('should not allow buying stamp with depth 16', async () => {
-    await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: ['stamp', 'buy', '--amount', '1', '--depth', '15'],
-    })
+    await invokeTestCli(['stamp', 'buy', '--amount', '1', '--depth', '15'])
     expect(getLastMessage()).toContain('[depth] must be at least 16')
   })
 })

--- a/test/command/upload.spec.ts
+++ b/test/command/upload.spec.ts
@@ -1,6 +1,5 @@
-import { cli } from 'furious-commander'
 import type { Upload } from '../../src/command/upload'
-import { optionParameters, rootCommandClasses } from '../../src/config'
+import { invokeTestCli } from '../utility'
 import { getStampOption } from '../utility/stamp'
 
 describe('Test Upload command', () => {
@@ -21,11 +20,7 @@ describe('Test Upload command', () => {
   it('should upload testpage folder', async () => {
     const commandKey = 'upload'
     const uploadFolderPath = `${__dirname}/../testpage`
-    const commandBuilder = await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: [commandKey, uploadFolderPath, ...getStampOption()],
-    })
+    const commandBuilder = await invokeTestCli([commandKey, uploadFolderPath, ...getStampOption()])
 
     expect(commandBuilder.initedCommands[0].command.name).toBe('upload')
     const command = commandBuilder.initedCommands[0].command as Upload
@@ -35,11 +30,7 @@ describe('Test Upload command', () => {
   it('should upload file', async () => {
     const commandKey = 'upload'
     const uploadFolderPath = `${__dirname}/../testpage/images/swarm.png`
-    const commandBuilder = await cli({
-      rootCommandClasses,
-      optionParameters,
-      testArguments: [commandKey, uploadFolderPath, ...getStampOption()],
-    })
+    const commandBuilder = await invokeTestCli([commandKey, uploadFolderPath, ...getStampOption()])
 
     expect(commandBuilder.initedCommands[0].command.name).toBe('upload')
     const command = commandBuilder.initedCommands[0].command as Upload

--- a/test/utility/index.ts
+++ b/test/utility/index.ts
@@ -1,7 +1,7 @@
 import { cli } from 'furious-commander'
 import { optionParameters, rootCommandClasses } from '../../src/config'
 
-export async function invokeTestCli(argv: string[]) {
+export async function invokeTestCli(argv: string[]): ReturnType<typeof cli> {
   const commandBuilder = await cli({
     rootCommandClasses,
     optionParameters,

--- a/test/utility/index.ts
+++ b/test/utility/index.ts
@@ -1,0 +1,12 @@
+import { cli } from 'furious-commander'
+import { optionParameters, rootCommandClasses } from '../../src/config'
+
+export async function invokeTestCli(argv: string[]) {
+  const commandBuilder = await cli({
+    rootCommandClasses,
+    optionParameters,
+    testArguments: argv,
+  })
+
+  return commandBuilder
+}

--- a/test/utility/stamp.ts
+++ b/test/utility/stamp.ts
@@ -1,13 +1,8 @@
-import { cli } from 'furious-commander'
+import { invokeTestCli } from '.'
 import { Buy } from '../../src/command/stamp/buy'
-import { optionParameters, rootCommandClasses } from '../../src/config'
 
 export const buyStamp = async (): Promise<string> => {
-  const execution = await cli({
-    rootCommandClasses,
-    optionParameters,
-    testArguments: ['stamp', 'buy', '--depth', '20', '--amount', '1'],
-  })
+  const execution = await invokeTestCli(['stamp', 'buy', '--depth', '20', '--amount', '1'])
   const command = execution.runnable as Buy
 
   return command.postageBatchId


### PR DESCRIPTION
Replace

```
await cli({
    rootCommandClasses,
    optionParameters,
    testArguments: argv,
  })
```

with

```
await invokeTestCli(argv)
```