### PR TITLE
feat: core update and stamp picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ethersphere/bee-js": "^0.9.0",
         "cli-progress": "^3.8.2",
         "ethereumjs-wallet": "^1.0.1",
-        "furious-commander": "1.0.9",
+        "furious-commander": "1.1.0",
         "inquirer": "^7.3.3",
         "kleur": "^4.1.4",
         "ora": "^5.3.0"
@@ -4221,9 +4221,9 @@
       }
     },
     "node_modules/cafe-args": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.13.tgz",
-      "integrity": "sha512-5ujwBCi+0e30wM0uyHmgveWD9hNdUtI7FqfUlBbRt0zFV7KLlJQPMI+mcP0uEGZ6X6+NeJDUcvF1WkR3WX0edQ=="
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.16.tgz",
+      "integrity": "sha512-dsWC2FcZK+3qO9usxg7EnhEchsHOyjx7k8+s3rEF9BOyU8OEWsMR3pPiX9Uf7dBnuYtigKciJV/jexUx+7xwww=="
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -6363,11 +6363,12 @@
       "dev": true
     },
     "node_modules/furious-commander": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/furious-commander/-/furious-commander-1.0.9.tgz",
-      "integrity": "sha512-0waoiqfaXL5JkmPQONZAeW3cU3XugOoakw1zOYDEHo7pJ1LEcdKkagC5AdMfQGSLu/RKj6xRh/Ezhxb1cPQwsg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/furious-commander/-/furious-commander-1.1.0.tgz",
+      "integrity": "sha512-060xPtbs7dTedok14eQFCydEUQngPhRRyVwVraISp74LbKl11rj0OkabgW8qfrLFGNfTl/Kb93upCqrkdhQPQQ==",
       "dependencies": {
-        "cafe-args": "^1.0.13",
+        "cafe-args": "1.0.16",
+        "omelette": "0.4.15-1",
         "reflect-metadata": "^0.1.13"
       },
       "engines": {
@@ -10115,6 +10116,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/omelette": {
+      "version": "0.4.15-1",
+      "resolved": "https://registry.npmjs.org/omelette/-/omelette-0.4.15-1.tgz",
+      "integrity": "sha512-sHU/IPll6uGCwESBH8HLZP1+sKmi2dXFy81u5oHvYnWaxJFvQ2A/QmCe7Qe0ce1DQONy85OSSTC4duZ/K5vXKA==",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/once": {
@@ -17238,9 +17247,9 @@
       }
     },
     "cafe-args": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.13.tgz",
-      "integrity": "sha512-5ujwBCi+0e30wM0uyHmgveWD9hNdUtI7FqfUlBbRt0zFV7KLlJQPMI+mcP0uEGZ6X6+NeJDUcvF1WkR3WX0edQ=="
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/cafe-args/-/cafe-args-1.0.16.tgz",
+      "integrity": "sha512-dsWC2FcZK+3qO9usxg7EnhEchsHOyjx7k8+s3rEF9BOyU8OEWsMR3pPiX9Uf7dBnuYtigKciJV/jexUx+7xwww=="
     },
     "call-bind": {
       "version": "1.0.2",
@@ -18897,11 +18906,12 @@
       "dev": true
     },
     "furious-commander": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/furious-commander/-/furious-commander-1.0.9.tgz",
-      "integrity": "sha512-0waoiqfaXL5JkmPQONZAeW3cU3XugOoakw1zOYDEHo7pJ1LEcdKkagC5AdMfQGSLu/RKj6xRh/Ezhxb1cPQwsg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/furious-commander/-/furious-commander-1.1.0.tgz",
+      "integrity": "sha512-060xPtbs7dTedok14eQFCydEUQngPhRRyVwVraISp74LbKl11rj0OkabgW8qfrLFGNfTl/Kb93upCqrkdhQPQQ==",
       "requires": {
-        "cafe-args": "^1.0.13",
+        "cafe-args": "1.0.16",
+        "omelette": "0.4.15-1",
         "reflect-metadata": "^0.1.13"
       }
     },
@@ -21705,6 +21715,11 @@
       "requires": {
         "isobject": "^3.0.1"
       }
+    },
+    "omelette": {
+      "version": "0.4.15-1",
+      "resolved": "https://registry.npmjs.org/omelette/-/omelette-0.4.15-1.tgz",
+      "integrity": "sha512-sHU/IPll6uGCwESBH8HLZP1+sKmi2dXFy81u5oHvYnWaxJFvQ2A/QmCe7Qe0ce1DQONy85OSSTC4duZ/K5vXKA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@ethersphere/bee-js": "^0.9.0",
     "cli-progress": "^3.8.2",
     "ethereumjs-wallet": "^1.0.1",
-    "furious-commander": "1.0.9",
+    "furious-commander": "1.1.0",
     "inquirer": "^7.3.3",
     "kleur": "^4.1.4",
     "ora": "^5.3.0"

--- a/src/command/feed/feed-command.ts
+++ b/src/command/feed/feed-command.ts
@@ -12,6 +12,7 @@ export class FeedCommand extends RootCommand {
     key: 'stamp',
     description: 'ID of the postage stamp to use',
     required: true,
+    noErrors: true,
   })
   public stamp!: string
 

--- a/src/command/feed/print.ts
+++ b/src/command/feed/print.ts
@@ -4,6 +4,7 @@ import { bold, green } from 'kleur'
 import { exit } from 'process'
 import { isSimpleWallet, isV3Wallet } from '../../service/identity'
 import { Identity } from '../../service/identity/types'
+import { pickStamp } from '../../service/stamp'
 import { FeedCommand } from './feed-command'
 
 export class Print extends FeedCommand implements LeafCommand {
@@ -27,6 +28,11 @@ export class Print extends FeedCommand implements LeafCommand {
     const addressString = this.address || (await this.getAddressString())
     const reader = this.bee.makeFeedReader('sequence', topic, addressString)
     const { reference, feedIndex, feedIndexNext } = await reader.download()
+
+    if (!this.stamp) {
+      this.stamp = await pickStamp(this.bee, this.console)
+    }
+
     const manifest = await this.bee.createFeedManifest(this.stamp, 'sequence', topic, addressString)
 
     this.console.verbose(bold(`Chunk Reference -> ${green(reference)}`))

--- a/src/command/feed/update.ts
+++ b/src/command/feed/update.ts
@@ -1,4 +1,5 @@
 import { LeafCommand, Option } from 'furious-commander'
+import { pickStamp } from '../../service/stamp'
 import { FeedCommand } from './feed-command'
 
 export class Update extends FeedCommand implements LeafCommand {
@@ -12,6 +13,11 @@ export class Update extends FeedCommand implements LeafCommand {
   public async run(): Promise<void> {
     super.init()
     await this.checkIdentity()
+
+    if (!this.stamp) {
+      this.stamp = await pickStamp(this.bee, this.console)
+    }
+
     await this.updateFeedAndPrint(this.reference)
     this.console.dim('Successfully updated feed.')
   }

--- a/src/command/feed/upload.ts
+++ b/src/command/feed/upload.ts
@@ -1,4 +1,5 @@
 import { Aggregation, LeafCommand } from 'furious-commander'
+import { pickStamp } from '../../service/stamp'
 import { Upload as FileUpload } from '../upload'
 import { FeedCommand } from './feed-command'
 
@@ -13,6 +14,13 @@ export class Upload extends FeedCommand implements LeafCommand {
   public async run(): Promise<void> {
     super.init()
     await this.checkIdentity()
+
+    if (!this.stamp) {
+      const stamp = await pickStamp(this.bee, this.console)
+      this.stamp = stamp
+      this.fileUpload.stamp = stamp
+    }
+
     const reference = await this.runUpload()
     await this.updateFeedAndPrint(reference)
     this.console.dim('Successfully uploaded to feed.')

--- a/src/command/root-command/command-log.ts
+++ b/src/command/root-command/command-log.ts
@@ -123,7 +123,7 @@ export class CommandLog {
   }
 
   public async promptList(choices: string[], message: string): Promise<string> {
-    const result = await prompt({ name: 'value', type: 'list', message, choices })
+    const result = await prompt({ name: 'value', type: 'list', message, choices, loop: false })
 
     return result.value
   }

--- a/src/command/stamp/show.ts
+++ b/src/command/stamp/show.ts
@@ -1,4 +1,5 @@
 import { Argument, LeafCommand } from 'furious-commander'
+import { pickStamp } from '../../service/stamp'
 import { StampCommand } from './stamp-command'
 
 export class Show extends StampCommand implements LeafCommand {
@@ -6,11 +7,15 @@ export class Show extends StampCommand implements LeafCommand {
 
   public readonly description = 'Show a specific postage stamp'
 
-  @Argument({ key: 'stamp', description: 'ID of the postage stamp', required: true })
+  @Argument({ key: 'stamp', description: 'ID of the postage stamp', required: true, noErrors: true })
   public stamp!: string
 
   public async run(): Promise<void> {
     super.init()
+
+    if (!this.stamp) {
+      this.stamp = await pickStamp(this.bee, this.console)
+    }
 
     this.console.verbose(`Looking up postage stamp ${this.stamp}...`)
 

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -7,6 +7,7 @@ import { bold, green } from 'kleur'
 import ora from 'ora'
 import { basename, join } from 'path'
 import { exit } from 'process'
+import { pickStamp } from '../service/stamp'
 import { fileExists, isGateway, sleep } from '../utils'
 import { RootCommand } from './root-command'
 import { VerbosityLevel } from './root-command/command-log'
@@ -27,6 +28,7 @@ export class Upload extends RootCommand implements LeafCommand {
     key: 'stamp',
     description: 'ID of the postage stamp to use',
     required: true,
+    noErrors: true,
   })
   public stamp!: string
 
@@ -77,6 +79,7 @@ export class Upload extends RootCommand implements LeafCommand {
 
   public async run(): Promise<void> {
     this.initCommand()
+
     let url: string
     let tag: Tag | undefined
 
@@ -92,6 +95,10 @@ export class Upload extends RootCommand implements LeafCommand {
       this.console.error('Please try again with the --skip-sync option.')
 
       return
+    }
+
+    if (!this.stamp) {
+      this.stamp = await pickStamp(this.bee, this.console)
     }
 
     if (!this.skipSync) {

--- a/src/service/stamp/index.ts
+++ b/src/service/stamp/index.ts
@@ -1,0 +1,18 @@
+import { Bee } from '@ethersphere/bee-js'
+import { exit } from 'process'
+import { CommandLog } from '../../command/root-command/command-log'
+
+export async function pickStamp(bee: Bee, console: CommandLog): Promise<string> {
+  const stamps = await bee.getAllPostageBatch()
+
+  if (!stamps.length) {
+    console.error('You need to have at least one stamp for this action.')
+    exit(1)
+  }
+
+  const choices = stamps.map(stamp => `${stamp.batchID} (${stamp.utilization})`)
+  const value = await console.promptList(choices, 'Please select a stamp for this action.')
+  const [hex] = value.split(' ')
+
+  return hex
+}

--- a/src/service/stamp/index.ts
+++ b/src/service/stamp/index.ts
@@ -21,7 +21,10 @@ export async function pickStamp(bee: Bee, console: CommandLog): Promise<string> 
   }
 
   const choices = stamps.map(stamp => `${stamp.batchID} (${stamp.utilization})`)
-  const value = await console.promptList(choices, 'Please select a stamp for this action.')
+  const value = await console.promptList(
+    choices,
+    'Please select a stamp for this action.\n\n  Stamp ID' + ' '.repeat(56) + ' Utilization\n',
+  )
   const [hex] = value.split(' ')
 
   return hex

--- a/src/service/stamp/index.ts
+++ b/src/service/stamp/index.ts
@@ -2,6 +2,16 @@ import { Bee } from '@ethersphere/bee-js'
 import { exit } from 'process'
 import { CommandLog } from '../../command/root-command/command-log'
 
+/**
+ * Displays an interactive stamp picker to select a Stamp ID.
+ *
+ * A typical use case is to prompt the user for a stamp, when
+ * the command requires one, but was not specified in `argv`.
+ *
+ * Makes a request via `bee` to fetch possible stamps.
+ *
+ * @returns {Promise<string>} Hex representation of the Stamp ID.
+ */
 export async function pickStamp(bee: Bee, console: CommandLog): Promise<string> {
   const stamps = await bee.getAllPostageBatch()
 


### PR DESCRIPTION
`--stamp` options can be interactively picked from the currently available stamp list.

---


Will also include new `furious-commander` version which brings enhancements:

* Conflicting options are printed in help
* `noErrors` property for tolerating missing required options and arguments (for Stamp Picker)