### PR TITLE
fix: remove invalid bin field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "Decentralised Storage"
   ],
   "bin": {
-    "@ethersphere/swarm-cli": "./dist/index.js",
     "swarm-cli": "./dist/index.js"
   },
   "homepage": "https://github.com/ethersphere/swarm-cli",


### PR DESCRIPTION
`@ethersphere/swarm-cli` as the bin name is invalid. Path separator should not be used in bin name. So remove it.

Giving yarn's error message as a reference:
```
warning @ethersphere/swarm-cli@0.7.0: Invalid bin entry for "@ethersphere/swarm-cli" (in "@ethersphere/swarm-cli").
```