### PR TITLE
feat: add pinning reupload-all

### DIFF
--- a/src/command/pinning/index.ts
+++ b/src/command/pinning/index.ts
@@ -2,6 +2,7 @@ import { GroupCommand } from 'furious-commander'
 import { List } from './list'
 import { Pin } from './pin'
 import { Reupload } from './reupload'
+import { ReuploadAll } from './reupload-all'
 import { Unpin } from './unpin'
 
 export class Pinning implements GroupCommand {
@@ -9,5 +10,5 @@ export class Pinning implements GroupCommand {
 
   public readonly description = 'Pin, unpin and check pinned chunks'
 
-  public subCommandClasses = [Pin, Unpin, List, Reupload]
+  public subCommandClasses = [Pin, Unpin, List, Reupload, ReuploadAll]
 }

--- a/src/command/pinning/reupload-all.ts
+++ b/src/command/pinning/reupload-all.ts
@@ -1,0 +1,38 @@
+import { LeafCommand } from 'furious-commander'
+import { PinningCommand } from './pinning-command'
+
+export class ReuploadAll extends PinningCommand implements LeafCommand {
+  public readonly name = 'reupload-all'
+
+  public readonly description = 'Reupload all locally pinned content'
+
+  public async run(): Promise<void> {
+    super.init()
+
+    const chunks = await this.bee.getAllPins()
+
+    const total = chunks.length
+    let successful = 0
+
+    this.console.log('Found ' + total + ' chunks to reupload...')
+
+    for (const chunk of chunks) {
+      try {
+        await this.reuploadOne(chunk)
+        successful++
+      } catch (error) {
+        this.console.error('Failed to reupload ' + chunk)
+        this.console.printBeeError(error)
+      }
+    }
+
+    this.console.log('Reuploaded ' + successful + ' out of ' + total + ' pinned chunks')
+    this.console.quiet(successful + '/' + total)
+  }
+
+  private async reuploadOne(chunk: string): Promise<void> {
+    this.console.log('Reuploading ' + chunk + '...')
+    await this.bee.reuploadPinnedData(chunk)
+    this.console.log('Reuploaded successfully.')
+  }
+}

--- a/test/command/pinning.spec.ts
+++ b/test/command/pinning.spec.ts
@@ -121,4 +121,10 @@ describe('Test Pinning command', () => {
     expect(consoleMessages).toHaveLength(4)
     expect(consoleMessages[3]).toContain('Reuploaded successfully.')
   })
+
+  it('should reupload all pinned content', async () => {
+    await invokeTestCli(['pinning', 'reupload-all'])
+    const last = consoleMessages[consoleMessages.length - 1]
+    expect(last).toMatch(/Reuploaded \d+ out of \d+ pinned chunks/)
+  })
 })


### PR DESCRIPTION
Adds command `pinning reupload-all`.

Ideally it would be `pinning reupload --all`, but the parser does not support conflicts between positional arguments and options. We can iterate on it very soon in the future though.

Alternatively, I can do `reupload --all` and `reupload --chunk <address>` if we want to keep them in one command.