### PR TITLE
refactor(test): describe command

### DIFF
--- a/test/command/cheque.spec.ts
+++ b/test/command/cheque.spec.ts
@@ -1,9 +1,7 @@
-import { existsSync, unlinkSync } from 'fs'
 import { Server } from 'http'
 import { bold, green } from 'kleur'
-import { join } from 'path'
 import { createChequeMockHttpServer } from '../http-mock/cheque-mock'
-import { invokeTestCli } from '../utility'
+import { describeCommand, invokeTestCli } from '../utility'
 
 async function runCommandAndExpectError(
   argv: string[],
@@ -15,143 +13,125 @@ async function runCommandAndExpectError(
   expect(lastConsoleMessage).toContain(errorPattern)
 }
 
-describe('Test Cheque command', () => {
-  const configFolderPath = join(__dirname, '..', 'testconfig')
-  const configFileName = 'cheque.config.json'
-  const configFilePath = join(configFolderPath, configFileName)
-  let consoleMessages: string[] = []
-  let server: Server
+describeCommand(
+  'Test Cheque command',
+  ({ consoleMessages }) => {
+    let server: Server
 
-  beforeAll(() => {
-    server = createChequeMockHttpServer(1377)
-    global.console.log = jest.fn(message => {
-      consoleMessages.push(message)
+    beforeAll(() => {
+      server = createChequeMockHttpServer(1377)
     })
-    global.console.error = jest.fn(message => {
-      consoleMessages.push(message)
+
+    afterAll(() => {
+      server.close()
     })
-    jest.spyOn(global.console, 'warn')
-    //set config environment variable
-    process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
-    process.env.SWARM_CLI_CONFIG_FILE = configFileName
 
-    //remove config file if it exists
-    if (existsSync(configFilePath)) unlinkSync(configFilePath)
-  })
+    it('should print helpful error message when api is unavailable', async () => {
+      process.env.BEE_DEBUG_API_URL = 'http://localhost:16737'
+      await invokeTestCli(['cheque', 'list'])
+      const length = consoleMessages.length
+      expect(consoleMessages[length - 3]).toBe(
+        bold().white().bgRed('Could not reach Debug API at http://localhost:16737'),
+      )
+      expect(consoleMessages[length - 2]).toBe(
+        bold().white().bgRed('Make sure you have the Debug API enabled in your Bee config'),
+      )
+      expect(consoleMessages[length - 1]).toBe(
+        bold().white().bgRed('or correct the URL with the --bee-debug-api-url option.'),
+      )
+    })
 
-  afterAll(() => {
-    server.close()
-  })
+    it('should print cheques', async () => {
+      process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
+      await invokeTestCli(['cheque', 'list'])
+      const length = consoleMessages.length
+      expect(consoleMessages[length - 1]).toBe(bold('Cheque Value: ') + '8944000000000 PLUR')
+    })
 
-  beforeEach(() => {
-    //clear stored console messages
-    consoleMessages = []
-  })
+    it('should not print cheques when --minimum is higher', async () => {
+      process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
+      await invokeTestCli(['cheque', 'list', '--minimum', '10000000000000000000'])
+      const length = consoleMessages.length
+      expect(consoleMessages[length - 1]).toContain('No uncashed cheques found')
+    })
 
-  it('should print helpful error message when api is unavailable', async () => {
-    process.env.BEE_DEBUG_API_URL = 'http://localhost:16737'
-    await invokeTestCli(['cheque', 'list'])
-    const length = consoleMessages.length
-    expect(consoleMessages[length - 3]).toBe(
-      bold().white().bgRed('Could not reach Debug API at http://localhost:16737'),
-    )
-    expect(consoleMessages[length - 2]).toBe(
-      bold().white().bgRed('Make sure you have the Debug API enabled in your Bee config'),
-    )
-    expect(consoleMessages[length - 1]).toBe(
-      bold().white().bgRed('or correct the URL with the --bee-debug-api-url option.'),
-    )
-  })
+    it('should print cheques when --minimum is lower', async () => {
+      process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
+      await invokeTestCli(['cheque', 'list', '--minimum', '1000'])
+      const length = consoleMessages.length
+      expect(consoleMessages[length - 1]).toContain('Cheque Value')
+    })
 
-  it('should print cheques', async () => {
-    process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
-    await invokeTestCli(['cheque', 'list'])
-    const length = consoleMessages.length
-    expect(consoleMessages[length - 1]).toBe(bold('Cheque Value: ') + '8944000000000 PLUR')
-  })
+    it('should print balance', async () => {
+      process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
+      await invokeTestCli(['cheque', 'balance'])
+      const length = consoleMessages.length
+      expect(consoleMessages[length - 2]).toBe(bold('Total: ') + '100026853000000000 PLUR')
+      expect(consoleMessages[length - 1]).toBe(bold('Available: ') + '100018560000000000 PLUR')
+    })
 
-  it('should not print cheques when --minimum is higher', async () => {
-    process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
-    await invokeTestCli(['cheque', 'list', '--minimum', '10000000000000000000'])
-    const length = consoleMessages.length
-    expect(consoleMessages[length - 1]).toContain('No uncashed cheques found')
-  })
+    it('should cashout all cheques', async () => {
+      process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
+      await invokeTestCli(['cheque', 'cashout', '--all'])
+      const length = consoleMessages.length
+      expect(consoleMessages[length - 3]).toBe(
+        bold('Peer Address: ') + '1105536d0f270ecaa9e6e4347e687d1a1afbde7b534354dfd7050d66b3c0faad',
+      )
+      expect(consoleMessages[length - 2]).toBe(bold('Cheque Value: ') + '8944000000000 PLUR')
+      expect(consoleMessages[length - 1]).toBe(
+        green(bold('Tx:           ')) + '0x11df9811dc8caaa1ff4389503f2493a8c46b30c0a0b5f8aa54adbb965374c0ae',
+      )
+    })
 
-  it('should print cheques when --minimum is lower', async () => {
-    process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
-    await invokeTestCli(['cheque', 'list', '--minimum', '1000'])
-    const length = consoleMessages.length
-    expect(consoleMessages[length - 1]).toContain('Cheque Value')
-  })
+    it('should allow specifying gas price and limit for cashout', async () => {
+      process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
+      await invokeTestCli(['cheque', 'cashout', '--all', '--gas-price', '100', '--gas-limit', '100'])
+      const length = consoleMessages.length
+      expect(consoleMessages[length - 1]).toBe(
+        green(bold('Tx:           ')) + '0x11df9811dc8caaa1ff4389503f2493a8c46b30c0a0b5f8aa54adbb965374c0ae',
+      )
+    })
 
-  it('should print balance', async () => {
-    process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
-    await invokeTestCli(['cheque', 'balance'])
-    const length = consoleMessages.length
-    expect(consoleMessages[length - 2]).toBe(bold('Total: ') + '100026853000000000 PLUR')
-    expect(consoleMessages[length - 1]).toBe(bold('Available: ') + '100018560000000000 PLUR')
-  })
+    it('should not cashout any cheques when --minimum is higher', async () => {
+      process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
+      await invokeTestCli(['cheque', 'cashout', '--all', '--minimum', '10000000000000000000'])
+      const length = consoleMessages.length
+      expect(consoleMessages[length - 1]).toContain('Found 0 cheques')
+    })
 
-  it('should cashout all cheques', async () => {
-    process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
-    await invokeTestCli(['cheque', 'cashout', '--all'])
-    const length = consoleMessages.length
-    expect(consoleMessages[length - 3]).toBe(
-      bold('Peer Address: ') + '1105536d0f270ecaa9e6e4347e687d1a1afbde7b534354dfd7050d66b3c0faad',
-    )
-    expect(consoleMessages[length - 2]).toBe(bold('Cheque Value: ') + '8944000000000 PLUR')
-    expect(consoleMessages[length - 1]).toBe(
-      green(bold('Tx:           ')) + '0x11df9811dc8caaa1ff4389503f2493a8c46b30c0a0b5f8aa54adbb965374c0ae',
-    )
-  })
+    it('should cashout one specific cheque', async () => {
+      process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
+      await invokeTestCli([
+        'cheque',
+        'cashout',
+        '--peer',
+        '1105536d0f270ecaa9e6e4347e687d1a1afbde7b534354dfd7050d66b3c0faad',
+      ])
+      const length = consoleMessages.length
+      expect(consoleMessages[length - 3]).toBe(
+        bold('Peer Address: ') + '1105536d0f270ecaa9e6e4347e687d1a1afbde7b534354dfd7050d66b3c0faad',
+      )
+      expect(consoleMessages[length - 2]).toBe(bold('Cheque Value: ') + '8944000000000 PLUR')
+      expect(consoleMessages[length - 1]).toBe(
+        green(bold('Tx:           ')) + '0x11df9811dc8caaa1ff4389503f2493a8c46b30c0a0b5f8aa54adbb965374c0ae',
+      )
+    })
 
-  it('should allow specifying gas price and limit for cashout', async () => {
-    process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
-    await invokeTestCli(['cheque', 'cashout', '--all', '--gas-price', '100', '--gas-limit', '100'])
-    const length = consoleMessages.length
-    expect(consoleMessages[length - 1]).toBe(
-      green(bold('Tx:           ')) + '0x11df9811dc8caaa1ff4389503f2493a8c46b30c0a0b5f8aa54adbb965374c0ae',
-    )
-  })
+    it('should raise error when withdrawing negative amount', async () => {
+      await runCommandAndExpectError(['cheque', 'withdraw', '-1'], '[amount] must be at least 1', consoleMessages)
+    })
 
-  it('should not cashout any cheques when --minimum is higher', async () => {
-    process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
-    await invokeTestCli(['cheque', 'cashout', '--all', '--minimum', '10000000000000000000'])
-    const length = consoleMessages.length
-    expect(consoleMessages[length - 1]).toContain('Found 0 cheques')
-  })
+    it('should raise error when depositing negative amount', async () => {
+      await runCommandAndExpectError(['cheque', 'deposit', '-42000000'], '[amount] must be at least 1', consoleMessages)
+    })
 
-  it('should cashout one specific cheque', async () => {
-    process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
-    await invokeTestCli([
-      'cheque',
-      'cashout',
-      '--peer',
-      '1105536d0f270ecaa9e6e4347e687d1a1afbde7b534354dfd7050d66b3c0faad',
-    ])
-    const length = consoleMessages.length
-    expect(consoleMessages[length - 3]).toBe(
-      bold('Peer Address: ') + '1105536d0f270ecaa9e6e4347e687d1a1afbde7b534354dfd7050d66b3c0faad',
-    )
-    expect(consoleMessages[length - 2]).toBe(bold('Cheque Value: ') + '8944000000000 PLUR')
-    expect(consoleMessages[length - 1]).toBe(
-      green(bold('Tx:           ')) + '0x11df9811dc8caaa1ff4389503f2493a8c46b30c0a0b5f8aa54adbb965374c0ae',
-    )
-  })
+    it('should raise error when withdrawing zero', async () => {
+      await runCommandAndExpectError(['cheque', 'withdraw', '0'], '[amount] must be at least 1', consoleMessages)
+    })
 
-  it('should raise error when withdrawing negative amount', async () => {
-    await runCommandAndExpectError(['cheque', 'withdraw', '-1'], '[amount] must be at least 1', consoleMessages)
-  })
-
-  it('should raise error when depositing negative amount', async () => {
-    await runCommandAndExpectError(['cheque', 'deposit', '-42000000'], '[amount] must be at least 1', consoleMessages)
-  })
-
-  it('should raise error when withdrawing zero', async () => {
-    await runCommandAndExpectError(['cheque', 'withdraw', '0'], '[amount] must be at least 1', consoleMessages)
-  })
-
-  it('should raise error when depositing zero', async () => {
-    await runCommandAndExpectError(['cheque', 'deposit', '0'], '[amount] must be at least 1', consoleMessages)
-  })
-})
+    it('should raise error when depositing zero', async () => {
+      await runCommandAndExpectError(['cheque', 'deposit', '0'], '[amount] must be at least 1', consoleMessages)
+    })
+  },
+  { configFileName: 'cheque' },
+)

--- a/test/command/cheque.spec.ts
+++ b/test/command/cheque.spec.ts
@@ -15,7 +15,7 @@ async function runCommandAndExpectError(
 
 describeCommand(
   'Test Cheque command',
-  ({ consoleMessages }) => {
+  ({ consoleMessages, getNthLastMessage, getLastMessage }) => {
     let server: Server
 
     beforeAll(() => {
@@ -29,56 +29,46 @@ describeCommand(
     it('should print helpful error message when api is unavailable', async () => {
       process.env.BEE_DEBUG_API_URL = 'http://localhost:16737'
       await invokeTestCli(['cheque', 'list'])
-      const length = consoleMessages.length
-      expect(consoleMessages[length - 3]).toBe(
-        bold().white().bgRed('Could not reach Debug API at http://localhost:16737'),
-      )
-      expect(consoleMessages[length - 2]).toBe(
+      expect(getNthLastMessage(3)).toBe(bold().white().bgRed('Could not reach Debug API at http://localhost:16737'))
+      expect(getNthLastMessage(2)).toBe(
         bold().white().bgRed('Make sure you have the Debug API enabled in your Bee config'),
       )
-      expect(consoleMessages[length - 1]).toBe(
-        bold().white().bgRed('or correct the URL with the --bee-debug-api-url option.'),
-      )
+      expect(getLastMessage()).toBe(bold().white().bgRed('or correct the URL with the --bee-debug-api-url option.'))
     })
 
     it('should print cheques', async () => {
       process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
       await invokeTestCli(['cheque', 'list'])
-      const length = consoleMessages.length
-      expect(consoleMessages[length - 1]).toBe(bold('Cheque Value: ') + '8944000000000 PLUR')
+      expect(getLastMessage()).toBe(bold('Cheque Value: ') + '8944000000000 PLUR')
     })
 
     it('should not print cheques when --minimum is higher', async () => {
       process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
       await invokeTestCli(['cheque', 'list', '--minimum', '10000000000000000000'])
-      const length = consoleMessages.length
-      expect(consoleMessages[length - 1]).toContain('No uncashed cheques found')
+      expect(getLastMessage()).toContain('No uncashed cheques found')
     })
 
     it('should print cheques when --minimum is lower', async () => {
       process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
       await invokeTestCli(['cheque', 'list', '--minimum', '1000'])
-      const length = consoleMessages.length
-      expect(consoleMessages[length - 1]).toContain('Cheque Value')
+      expect(getLastMessage()).toContain('Cheque Value')
     })
 
     it('should print balance', async () => {
       process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
       await invokeTestCli(['cheque', 'balance'])
-      const length = consoleMessages.length
-      expect(consoleMessages[length - 2]).toBe(bold('Total: ') + '100026853000000000 PLUR')
-      expect(consoleMessages[length - 1]).toBe(bold('Available: ') + '100018560000000000 PLUR')
+      expect(getNthLastMessage(2)).toBe(bold('Total: ') + '100026853000000000 PLUR')
+      expect(getLastMessage()).toBe(bold('Available: ') + '100018560000000000 PLUR')
     })
 
     it('should cashout all cheques', async () => {
       process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
       await invokeTestCli(['cheque', 'cashout', '--all'])
-      const length = consoleMessages.length
-      expect(consoleMessages[length - 3]).toBe(
+      expect(getNthLastMessage(3)).toBe(
         bold('Peer Address: ') + '1105536d0f270ecaa9e6e4347e687d1a1afbde7b534354dfd7050d66b3c0faad',
       )
-      expect(consoleMessages[length - 2]).toBe(bold('Cheque Value: ') + '8944000000000 PLUR')
-      expect(consoleMessages[length - 1]).toBe(
+      expect(getNthLastMessage(2)).toBe(bold('Cheque Value: ') + '8944000000000 PLUR')
+      expect(getLastMessage()).toBe(
         green(bold('Tx:           ')) + '0x11df9811dc8caaa1ff4389503f2493a8c46b30c0a0b5f8aa54adbb965374c0ae',
       )
     })
@@ -86,8 +76,7 @@ describeCommand(
     it('should allow specifying gas price and limit for cashout', async () => {
       process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
       await invokeTestCli(['cheque', 'cashout', '--all', '--gas-price', '100', '--gas-limit', '100'])
-      const length = consoleMessages.length
-      expect(consoleMessages[length - 1]).toBe(
+      expect(getLastMessage()).toBe(
         green(bold('Tx:           ')) + '0x11df9811dc8caaa1ff4389503f2493a8c46b30c0a0b5f8aa54adbb965374c0ae',
       )
     })
@@ -95,8 +84,7 @@ describeCommand(
     it('should not cashout any cheques when --minimum is higher', async () => {
       process.env.BEE_DEBUG_API_URL = 'http://localhost:1377'
       await invokeTestCli(['cheque', 'cashout', '--all', '--minimum', '10000000000000000000'])
-      const length = consoleMessages.length
-      expect(consoleMessages[length - 1]).toContain('Found 0 cheques')
+      expect(getLastMessage()).toContain('Found 0 cheques')
     })
 
     it('should cashout one specific cheque', async () => {
@@ -107,12 +95,11 @@ describeCommand(
         '--peer',
         '1105536d0f270ecaa9e6e4347e687d1a1afbde7b534354dfd7050d66b3c0faad',
       ])
-      const length = consoleMessages.length
-      expect(consoleMessages[length - 3]).toBe(
+      expect(getNthLastMessage(3)).toBe(
         bold('Peer Address: ') + '1105536d0f270ecaa9e6e4347e687d1a1afbde7b534354dfd7050d66b3c0faad',
       )
-      expect(consoleMessages[length - 2]).toBe(bold('Cheque Value: ') + '8944000000000 PLUR')
-      expect(consoleMessages[length - 1]).toBe(
+      expect(getNthLastMessage(2)).toBe(bold('Cheque Value: ') + '8944000000000 PLUR')
+      expect(getLastMessage()).toBe(
         green(bold('Tx:           ')) + '0x11df9811dc8caaa1ff4389503f2493a8c46b30c0a0b5f8aa54adbb965374c0ae',
       )
     })

--- a/test/command/feed.spec.ts
+++ b/test/command/feed.spec.ts
@@ -5,7 +5,7 @@ import { getStampOption } from '../utility/stamp'
 
 describeCommand(
   'Test Feed command',
-  ({ consoleMessages }) => {
+  ({ consoleMessages, getLastMessage }) => {
     it('should upload file, update feed and print it', async () => {
       // create identity
       await invokeTestCli(['identity', 'create', 'test', '--password', 'test'])
@@ -36,8 +36,7 @@ describeCommand(
         '--quiet',
         ...getStampOption(),
       ])
-      const length = consoleMessages.length
-      expect(consoleMessages[length - 1]).toMatch(/[a-z0-9]{64}/)
+      expect(getLastMessage()).toMatch(/[a-z0-9]{64}/)
     })
 
     it('should print feed using address only', async () => {
@@ -58,8 +57,7 @@ describeCommand(
       ])
       // print with address
       await invokeTestCli(['feed', 'print', '--address', address, '--quiet', ...getStampOption()])
-      const length = consoleMessages.length
-      expect(consoleMessages[length - 1]).toMatch(/[a-z0-9]{64}/)
+      expect(getLastMessage()).toMatch(/[a-z0-9]{64}/)
     })
 
     it('should update feeds', async () => {

--- a/test/command/feed.spec.ts
+++ b/test/command/feed.spec.ts
@@ -1,111 +1,90 @@
-import { existsSync, unlinkSync } from 'fs'
-import { join } from 'path'
 import { Create } from '../../src/command/identity/create'
 import { Upload } from '../../src/command/upload'
-import { invokeTestCli } from '../utility'
+import { describeCommand, invokeTestCli } from '../utility'
 import { getStampOption } from '../utility/stamp'
 
-describe('Test Feed command', () => {
-  const configFolderPath = join(__dirname, '..', 'testconfig')
-  const configFileName = 'feed.config.json'
-  const configFilePath = join(configFolderPath, configFileName)
-  let consoleMessages: string[] = []
-
-  beforeAll(() => {
-    global.console.log = jest.fn(message => {
-      consoleMessages.push(message)
+describeCommand(
+  'Test Feed command',
+  ({ consoleMessages }) => {
+    it('should upload file, update feed and print it', async () => {
+      // create identity
+      await invokeTestCli(['identity', 'create', 'test', '--password', 'test'])
+      // upload
+      await invokeTestCli([
+        'feed',
+        'upload',
+        `${__dirname}/../testpage/images/swarm.png`,
+        '--identity',
+        'test',
+        '--topic-string',
+        'test',
+        '--password',
+        'test',
+        '--quiet',
+        ...getStampOption(),
+      ])
+      // print with identity and password
+      await invokeTestCli([
+        'feed',
+        'print',
+        '--identity',
+        'test',
+        '--topic-string',
+        'test',
+        '--password',
+        'test',
+        '--quiet',
+        ...getStampOption(),
+      ])
+      const length = consoleMessages.length
+      expect(consoleMessages[length - 1]).toMatch(/[a-z0-9]{64}/)
     })
-    jest.spyOn(global.console, 'warn')
-    //set config environment variable
-    process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
-    process.env.SWARM_CLI_CONFIG_FILE = configFileName
 
-    //remove config file if it exists
-    if (existsSync(configFilePath)) unlinkSync(configFilePath)
-  })
+    it('should print feed using address only', async () => {
+      // create identity
+      const commandBuilder = await invokeTestCli(['identity', 'create', 'test2', '--password', 'test'])
+      const identityCreate = commandBuilder.runnable as Create
+      const address = identityCreate.wallet.getAddressString()
+      // upload
+      await invokeTestCli([
+        'feed',
+        'upload',
+        `${__dirname}/../testpage/index.html`,
+        '--identity',
+        'test2',
+        '--password',
+        'test',
+        ...getStampOption(),
+      ])
+      // print with address
+      await invokeTestCli(['feed', 'print', '--address', address, '--quiet', ...getStampOption()])
+      const length = consoleMessages.length
+      expect(consoleMessages[length - 1]).toMatch(/[a-z0-9]{64}/)
+    })
 
-  beforeEach(() => {
-    //clear stored console messages
-    consoleMessages = []
-  })
-
-  it('should upload file, update feed and print it', async () => {
-    // create identity
-    await invokeTestCli(['identity', 'create', 'test', '--password', 'test'])
-    // upload
-    await invokeTestCli([
-      'feed',
-      'upload',
-      `${__dirname}/../testpage/images/swarm.png`,
-      '--identity',
-      'test',
-      '--topic-string',
-      'test',
-      '--password',
-      'test',
-      '--quiet',
-      ...getStampOption(),
-    ])
-    // print with identity and password
-    await invokeTestCli([
-      'feed',
-      'print',
-      '--identity',
-      'test',
-      '--topic-string',
-      'test',
-      '--password',
-      'test',
-      '--quiet',
-      ...getStampOption(),
-    ])
-    const length = consoleMessages.length
-    expect(consoleMessages[length - 1]).toMatch(/[a-z0-9]{64}/)
-  })
-
-  it('should print feed using address only', async () => {
-    // create identity
-    const commandBuilder = await invokeTestCli(['identity', 'create', 'test2', '--password', 'test'])
-    const identityCreate = commandBuilder.runnable as Create
-    const address = identityCreate.wallet.getAddressString()
-    // upload
-    await invokeTestCli([
-      'feed',
-      'upload',
-      `${__dirname}/../testpage/index.html`,
-      '--identity',
-      'test2',
-      '--password',
-      'test',
-      ...getStampOption(),
-    ])
-    // print with address
-    await invokeTestCli(['feed', 'print', '--address', address, '--quiet', ...getStampOption()])
-    const length = consoleMessages.length
-    expect(consoleMessages[length - 1]).toMatch(/[a-z0-9]{64}/)
-  })
-
-  it('should update feeds', async () => {
-    await invokeTestCli(['identity', 'create', 'update-feed-test', '-P', '1234', '-v'])
-    const uploadCommand = await invokeTestCli(['upload', 'README.md', '--skip-sync', ...getStampOption()])
-    const upload = uploadCommand.runnable as Upload
-    const { hash } = upload
-    consoleMessages = []
-    await invokeTestCli([
-      'feed',
-      'update',
-      '--topic-string',
-      'test-topic',
-      '-i',
-      'update-feed-test',
-      '-P',
-      '1234',
-      '-r',
-      hash,
-      ...getStampOption(),
-    ])
-    expect(consoleMessages).toHaveLength(1)
-    expect(consoleMessages[0]).toContain('Feed Manifest URL')
-    expect(consoleMessages[0]).toContain('/bzz/')
-  })
-})
+    it('should update feeds', async () => {
+      await invokeTestCli(['identity', 'create', 'update-feed-test', '-P', '1234', '-v'])
+      const uploadCommand = await invokeTestCli(['upload', 'README.md', '--skip-sync', ...getStampOption()])
+      const upload = uploadCommand.runnable as Upload
+      const { hash } = upload
+      consoleMessages.length = 0
+      await invokeTestCli([
+        'feed',
+        'update',
+        '--topic-string',
+        'test-topic',
+        '-i',
+        'update-feed-test',
+        '-P',
+        '1234',
+        '-r',
+        hash,
+        ...getStampOption(),
+      ])
+      expect(consoleMessages).toHaveLength(1)
+      expect(consoleMessages[0]).toContain('Feed Manifest URL')
+      expect(consoleMessages[0]).toContain('/bzz/')
+    })
+  },
+  { configFileName: 'feed' },
+)

--- a/test/command/identity.spec.ts
+++ b/test/command/identity.spec.ts
@@ -1,21 +1,19 @@
 import Wallet from 'ethereumjs-wallet'
-import { access, writeFileSync } from 'fs'
+import { writeFileSync } from 'fs'
 import { join } from 'path'
-import { promisify } from 'util'
 import { List } from '../../src/command/identity/list'
+import { fileExists } from '../../src/utils'
 import { describeCommand, invokeTestCli } from '../utility'
 
 describeCommand(
   'Test Identity command',
   ({ consoleMessages, configFolderPath, getLastMessage }) => {
-    const existFile = promisify(access)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const configFilePath = process.env.SWARM_CLI_CONFIG_FILE_PATH!
 
     it('should create default config on the first run', async () => {
       await invokeTestCli(['identity', 'list'])
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(await existFile(configFilePath)).toBeUndefined() //TODO why is it true for undefined?
+      expect(fileExists(configFilePath)).toBe(true)
     })
 
     it('should create V3 identity "main"', async () => {
@@ -73,10 +71,7 @@ describeCommand(
       // then import it
       await invokeTestCli(['identity', 'import', path, '--identity-name', 'import-test', '--password', '123'])
       // and check for successful import message
-      const successfulImportIndex = consoleMessages.length - 1
-      expect(consoleMessages[successfulImportIndex]).toContain(
-        "V3 Wallet imported as identity 'import-test' successfully",
-      )
+      expect(getLastMessage()).toContain("V3 Wallet imported as identity 'import-test' successfully")
     })
   },
   { configFileName: 'config' },

--- a/test/command/identity.spec.ts
+++ b/test/command/identity.spec.ts
@@ -1,97 +1,84 @@
 import Wallet from 'ethereumjs-wallet'
-import { access, existsSync, unlinkSync, writeFileSync } from 'fs'
+import { access, writeFileSync } from 'fs'
 import { join } from 'path'
 import { promisify } from 'util'
 import { List } from '../../src/command/identity/list'
-import { invokeTestCli } from '../utility'
+import { describeCommand, invokeTestCli } from '../utility'
 
-describe('Test Identity command', () => {
-  const configFolderPath = join(__dirname, '..', 'testconfig')
-  const configFilePath = join(configFolderPath, 'config.json')
-  const existFile = promisify(access)
-  let consoleMessages: string[] = []
+describeCommand(
+  'Test Identity command',
+  ({ consoleMessages, configFolderPath }) => {
+    const existFile = promisify(access)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const configFilePath = process.env.SWARM_CLI_CONFIG_FILE_PATH!
 
-  beforeAll(() => {
-    global.console.log = jest.fn(message => {
-      consoleMessages.push(message)
+    it('should create default config on the first run', async () => {
+      await invokeTestCli(['identity', 'list'])
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(await existFile(configFilePath)).toBeUndefined() //TODO why is it true for undefined?
     })
-    jest.spyOn(global.console, 'warn')
-    //set config environment variable
-    process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
 
-    //remove config file if it exists
-    if (existsSync(configFilePath)) unlinkSync(configFilePath)
-  })
+    it('should create V3 identity "main"', async () => {
+      // create identity
+      await invokeTestCli(['identity', 'create', '--password', '1234'])
+      expect(consoleMessages[0]).toBe('Keypair has been generated successfully!')
+    })
 
-  beforeEach(() => {
-    //clear stored console messages
-    consoleMessages = []
-  })
+    it('should create simple identity "temporary-identity"', async () => {
+      // create identity
+      await invokeTestCli(['identity', 'create', 'temporary-identity', '--only-keypair'])
+      expect(consoleMessages[0]).toBe('Keypair has been generated successfully!')
+    })
 
-  it('should create default config on the first run', async () => {
-    await invokeTestCli(['identity', 'list'])
-    expect(await existFile(configFilePath)).toBeUndefined()
-  })
+    it('should list already created identities', async () => {
+      // create identity
+      const commandBuilder = await invokeTestCli(['identity', 'list'])
+      expect(consoleMessages[0]).toContain('List of your identities')
+      expect(consoleMessages[2]).toContain('Identity name')
+      expect(consoleMessages[2]).toContain('main')
+      expect(consoleMessages[6]).toContain('Identity name')
+      expect(consoleMessages[6]).toContain('temporary-identity')
+      const listCommand = commandBuilder.runnable as List
+      expect(Object.keys(listCommand.commandConfig.config.identities)).toHaveLength(2)
+      expect(listCommand.commandConfig.config.identities.main).toBeDefined()
+      expect(listCommand.commandConfig.config.identities['temporary-identity']).toBeDefined()
+    })
 
-  it('should create V3 identity "main"', async () => {
-    // create identity
-    await invokeTestCli(['identity', 'create', '--password', '1234'])
-    expect(consoleMessages[0]).toBe('Keypair has been generated successfully!')
-  })
+    it('should remove identity "temporary-identity"', async () => {
+      // remove identity
+      await invokeTestCli(['identity', 'remove', 'temporary-identity', '-f'])
+      expect(consoleMessages[0]).toBe('Identity has been successfully removed')
+      // check it removed from the identity list
+      const commandBuilder = await invokeTestCli(['identity', 'list'])
+      const listCommand = commandBuilder.runnable as List
+      expect(Object.keys(listCommand.commandConfig.config.identities)).toHaveLength(1)
+      expect(listCommand.commandConfig.config.identities['temporary-identity']).toBeUndefined()
+    })
 
-  it('should create simple identity "temporary-identity"', async () => {
-    // create identity
-    await invokeTestCli(['identity', 'create', 'temporary-identity', '--only-keypair'])
-    expect(consoleMessages[0]).toBe('Keypair has been generated successfully!')
-  })
+    it('should export v3 identity', async () => {
+      // first create a v3 identity
+      await invokeTestCli(['identity', 'create', 'v3-identity', '--password', 'test'])
+      // then export it
+      await invokeTestCli(['identity', 'export', 'v3-identity'])
+      // and check if the last console message looked like a v3 wallet json
+      const exportIndex = consoleMessages.length - 1
+      expect(consoleMessages[exportIndex]).toContain('"ciphertext"')
+    })
 
-  it('should list already created identities', async () => {
-    // create identity
-    const commandBuilder = await invokeTestCli(['identity', 'list'])
-    expect(consoleMessages[0]).toContain('List of your identities')
-    expect(consoleMessages[2]).toContain('Identity name')
-    expect(consoleMessages[2]).toContain('main')
-    expect(consoleMessages[6]).toContain('Identity name')
-    expect(consoleMessages[6]).toContain('temporary-identity')
-    const listCommand = commandBuilder.runnable as List
-    expect(Object.keys(listCommand.commandConfig.config.identities)).toHaveLength(2)
-    expect(listCommand.commandConfig.config.identities.main).toBeDefined()
-    expect(listCommand.commandConfig.config.identities['temporary-identity']).toBeDefined()
-  })
-
-  it('should remove identity "temporary-identity"', async () => {
-    // remove identity
-    await invokeTestCli(['identity', 'remove', 'temporary-identity', '-f'])
-    expect(consoleMessages[0]).toBe('Identity has been successfully removed')
-    // check it removed from the identity list
-    const commandBuilder = await invokeTestCli(['identity', 'list'])
-    const listCommand = commandBuilder.runnable as List
-    expect(Object.keys(listCommand.commandConfig.config.identities)).toHaveLength(1)
-    expect(listCommand.commandConfig.config.identities['temporary-identity']).toBeUndefined()
-  })
-
-  it('should export v3 identity', async () => {
-    // first create a v3 identity
-    await invokeTestCli(['identity', 'create', 'v3-identity', '--password', 'test'])
-    // then export it
-    await invokeTestCli(['identity', 'export', 'v3-identity'])
-    // and check if the last console message looked like a v3 wallet json
-    const exportIndex = consoleMessages.length - 1
-    expect(consoleMessages[exportIndex]).toContain('"ciphertext"')
-  })
-
-  it('should import v3 identity', async () => {
-    // first save a v3 keystore to a file
-    const wallet = Wallet.generate()
-    const v3string = await wallet.toV3String('123')
-    const path = join(configFolderPath, 'v3-keystore.json')
-    writeFileSync(path, v3string)
-    // then import it
-    await invokeTestCli(['identity', 'import', path, '--identity-name', 'import-test', '--password', '123'])
-    // and check for successful import message
-    const successfulImportIndex = consoleMessages.length - 1
-    expect(consoleMessages[successfulImportIndex]).toContain(
-      "V3 Wallet imported as identity 'import-test' successfully",
-    )
-  })
-})
+    it('should import v3 identity', async () => {
+      // first save a v3 keystore to a file
+      const wallet = Wallet.generate()
+      const v3string = await wallet.toV3String('123')
+      const path = join(configFolderPath, 'v3-keystore.json')
+      writeFileSync(path, v3string)
+      // then import it
+      await invokeTestCli(['identity', 'import', path, '--identity-name', 'import-test', '--password', '123'])
+      // and check for successful import message
+      const successfulImportIndex = consoleMessages.length - 1
+      expect(consoleMessages[successfulImportIndex]).toContain(
+        "V3 Wallet imported as identity 'import-test' successfully",
+      )
+    })
+  },
+  { configFileName: 'config' },
+)

--- a/test/command/identity.spec.ts
+++ b/test/command/identity.spec.ts
@@ -7,7 +7,7 @@ import { describeCommand, invokeTestCli } from '../utility'
 
 describeCommand(
   'Test Identity command',
-  ({ consoleMessages, configFolderPath }) => {
+  ({ consoleMessages, configFolderPath, getLastMessage }) => {
     const existFile = promisify(access)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const configFilePath = process.env.SWARM_CLI_CONFIG_FILE_PATH!
@@ -61,8 +61,7 @@ describeCommand(
       // then export it
       await invokeTestCli(['identity', 'export', 'v3-identity'])
       // and check if the last console message looked like a v3 wallet json
-      const exportIndex = consoleMessages.length - 1
-      expect(consoleMessages[exportIndex]).toContain('"ciphertext"')
+      expect(getLastMessage()).toContain('"ciphertext"')
     })
 
     it('should import v3 identity', async () => {

--- a/test/command/pinning.spec.ts
+++ b/test/command/pinning.spec.ts
@@ -77,7 +77,7 @@ describeCommand(
       expect(consoleMessages[1]).toContain('No pinned chunk found with that address.')
     })
 
-    it('should allow reuploading pinned file', async () => {
+    test.skip('should allow reuploading pinned file', async () => {
       const invocation = await invokeTestCli(['upload', 'README.md', '--pin', ...getStampOption()])
       const upload = invocation.runnable as Upload
       const { hash } = upload
@@ -86,7 +86,7 @@ describeCommand(
       expect(consoleMessages[3]).toContain('Reuploaded successfully.')
     })
 
-    it('should allow reuploading pinned folder', async () => {
+    test.skip('should allow reuploading pinned folder', async () => {
       const invocation = await invokeTestCli(['upload', 'test', '--pin', ...getStampOption()])
       const upload = invocation.runnable as Upload
       const { hash } = upload

--- a/test/command/pinning.spec.ts
+++ b/test/command/pinning.spec.ts
@@ -77,8 +77,7 @@ describeCommand(
       expect(consoleMessages[1]).toContain('No pinned chunk found with that address.')
     })
 
-    // FIXME https://github.com/ethersphere/bee/issues/1897
-    test.skip('should allow reuploading pinned file', async () => {
+    it('should allow reuploading pinned file', async () => {
       const invocation = await invokeTestCli(['upload', 'README.md', '--pin', ...getStampOption()])
       const upload = invocation.runnable as Upload
       const { hash } = upload
@@ -87,8 +86,7 @@ describeCommand(
       expect(consoleMessages[3]).toContain('Reuploaded successfully.')
     })
 
-    // FIXME https://github.com/ethersphere/bee/issues/1897
-    test.skip('should allow reuploading pinned folder', async () => {
+    it('should allow reuploading pinned folder', async () => {
       const invocation = await invokeTestCli(['upload', 'test', '--pin', ...getStampOption()])
       const upload = invocation.runnable as Upload
       const { hash } = upload

--- a/test/command/pinning.spec.ts
+++ b/test/command/pinning.spec.ts
@@ -12,7 +12,7 @@ async function uploadAndGetHash(path: string, indexDocument?: string): Promise<s
 
 describeCommand(
   'Test Pinning command',
-  ({ consoleMessages }) => {
+  ({ consoleMessages, getLastMessage }) => {
     it('should pin a collection with index.html index document', async () => {
       const hash = await uploadAndGetHash('test/testpage')
       expect(hash).toMatch(/[a-z0-9]{64}/)
@@ -99,8 +99,7 @@ describeCommand(
 
     it('should reupload all pinned content', async () => {
       await invokeTestCli(['pinning', 'reupload-all'])
-      const last = consoleMessages[consoleMessages.length - 1]
-      expect(last).toMatch(/Reuploaded \d+ out of \d+ pinned chunks/)
+      expect(getLastMessage()).toMatch(/Reuploaded \d+ out of \d+ pinned chunks/)
     })
   },
   { configFileName: 'pinning' },

--- a/test/command/pinning.spec.ts
+++ b/test/command/pinning.spec.ts
@@ -1,7 +1,5 @@
-import { existsSync, unlinkSync } from 'fs'
-import { join } from 'path'
 import { Upload } from '../../src/command/upload'
-import { invokeTestCli } from '../utility'
+import { describeCommand, invokeTestCli } from '../utility'
 import { getStampOption } from '../utility/stamp'
 
 async function uploadAndGetHash(path: string, indexDocument?: string): Promise<string> {
@@ -12,120 +10,98 @@ async function uploadAndGetHash(path: string, indexDocument?: string): Promise<s
   return hash
 }
 
-describe('Test Pinning command', () => {
-  const configFolderPath = join(__dirname, '..', 'testconfig')
-  const configFileName = 'pinning.config.json'
-  const configFilePath = join(configFolderPath, configFileName)
-  let consoleMessages: string[] = []
-
-  beforeAll(() => {
-    global.console.log = jest.fn(message => {
-      consoleMessages.push(message)
+describeCommand(
+  'Test Pinning command',
+  ({ consoleMessages }) => {
+    it('should pin a collection with index.html index document', async () => {
+      const hash = await uploadAndGetHash('test/testpage')
+      expect(hash).toMatch(/[a-z0-9]{64}/)
+      await invokeTestCli(['pinning', 'pin', hash])
+      expect(consoleMessages).toHaveLength(4)
+      expect(consoleMessages[3]).toBe('Pinned successfully')
     })
-    global.console.error = jest.fn(message => {
-      consoleMessages.push(message)
+
+    it('should pin a collection with no index document', async () => {
+      const hash = await uploadAndGetHash('test/command')
+      expect(hash).toMatch(/[a-z0-9]{64}/)
+      await invokeTestCli(['pinning', 'pin', hash])
+      expect(consoleMessages).toHaveLength(3)
+      const successMessage = consoleMessages[2]
+      expect(successMessage).toBe('Pinned successfully')
     })
-    jest.spyOn(global.console, 'warn')
-    //set config environment variable
-    process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
-    process.env.SWARM_CLI_CONFIG_FILE = configFileName
 
-    //remove config file if it exists
-    if (existsSync(configFilePath)) unlinkSync(configFilePath)
-  })
+    it('should pin a collection with explicit index document', async () => {
+      const hash = await uploadAndGetHash('test/command', 'pinning.spec.ts')
+      expect(hash).toMatch(/[a-z0-9]{64}/)
+      await invokeTestCli(['pinning', 'pin', hash])
+      expect(consoleMessages).toHaveLength(3)
+      const successMessage = consoleMessages[2]
+      expect(successMessage).toBe('Pinned successfully')
+    })
 
-  beforeEach(() => {
-    //clear stored console messages
-    consoleMessages = []
-  })
+    it('should list less pinned items after unpinning', async () => {
+      const hash = await uploadAndGetHash('test/command')
+      consoleMessages.length = 0
+      await invokeTestCli(['pinning', 'list'])
+      const containsHash = consoleMessages.some(message => message.includes(hash))
+      expect(containsHash).toBe(true)
+      const countOfItemsBefore = consoleMessages.length
+      expect(countOfItemsBefore).toBeGreaterThanOrEqual(1)
+      consoleMessages.length = 0
+      await invokeTestCli(['pinning', 'unpin', hash])
+      expect(consoleMessages.length).toBe(1)
+      expect(consoleMessages[0]).toContain('Unpinned successfully')
+      consoleMessages.length = 0
+      await invokeTestCli(['pinning', 'list'])
+      const containsHashAfterUnpin = consoleMessages.some(message => message.includes(hash))
+      expect(containsHashAfterUnpin).toBe(false)
+      const countOfItemsAfter = consoleMessages.length
+      expect(countOfItemsAfter).toBeLessThan(countOfItemsBefore)
+    })
 
-  it('should pin a collection with index.html index document', async () => {
-    const hash = await uploadAndGetHash('test/testpage')
-    expect(hash).toMatch(/[a-z0-9]{64}/)
-    await invokeTestCli(['pinning', 'pin', hash])
-    expect(consoleMessages).toHaveLength(4)
-    expect(consoleMessages[3]).toBe('Pinned successfully')
-  })
+    it('should print custom 404 when pinning chunk that does not exist', async () => {
+      await invokeTestCli(['pinning', 'pin', 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'])
+      expect(consoleMessages).toHaveLength(2)
+      expect(consoleMessages[0]).toContain(
+        'Could not pin ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+      )
+      expect(consoleMessages[1]).toContain('No root chunk found with that address.')
+    })
 
-  it('should pin a collection with no index document', async () => {
-    const hash = await uploadAndGetHash('test/command')
-    expect(hash).toMatch(/[a-z0-9]{64}/)
-    await invokeTestCli(['pinning', 'pin', hash])
-    expect(consoleMessages).toHaveLength(3)
-    const successMessage = consoleMessages[2]
-    expect(successMessage).toBe('Pinned successfully')
-  })
+    it('should print custom 404 when unpinning chunk that does not exist', async () => {
+      await invokeTestCli(['pinning', 'unpin', 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'])
+      expect(consoleMessages).toHaveLength(2)
+      expect(consoleMessages[0]).toContain(
+        'Could not unpin ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+      )
+      expect(consoleMessages[1]).toContain('No pinned chunk found with that address.')
+    })
 
-  it('should pin a collection with explicit index document', async () => {
-    const hash = await uploadAndGetHash('test/command', 'pinning.spec.ts')
-    expect(hash).toMatch(/[a-z0-9]{64}/)
-    await invokeTestCli(['pinning', 'pin', hash])
-    expect(consoleMessages).toHaveLength(3)
-    const successMessage = consoleMessages[2]
-    expect(successMessage).toBe('Pinned successfully')
-  })
+    // FIXME https://github.com/ethersphere/bee/issues/1897
+    test.skip('should allow reuploading pinned file', async () => {
+      const invocation = await invokeTestCli(['upload', 'README.md', '--pin', ...getStampOption()])
+      const upload = invocation.runnable as Upload
+      const { hash } = upload
+      await invokeTestCli(['pinning', 'reupload', hash])
+      expect(consoleMessages).toHaveLength(4)
+      expect(consoleMessages[3]).toContain('Reuploaded successfully.')
+    })
 
-  it('should list less pinned items after unpinning', async () => {
-    const hash = await uploadAndGetHash('test/command')
-    consoleMessages = []
-    await invokeTestCli(['pinning', 'list'])
-    const containsHash = consoleMessages.some(message => message.includes(hash))
-    expect(containsHash).toBe(true)
-    const countOfItemsBefore = consoleMessages.length
-    expect(countOfItemsBefore).toBeGreaterThanOrEqual(1)
-    consoleMessages = []
-    await invokeTestCli(['pinning', 'unpin', hash])
-    expect(consoleMessages.length).toBe(1)
-    expect(consoleMessages[0]).toContain('Unpinned successfully')
-    consoleMessages = []
-    await invokeTestCli(['pinning', 'list'])
-    const containsHashAfterUnpin = consoleMessages.some(message => message.includes(hash))
-    expect(containsHashAfterUnpin).toBe(false)
-    const countOfItemsAfter = consoleMessages.length
-    expect(countOfItemsAfter).toBeLessThan(countOfItemsBefore)
-  })
+    // FIXME https://github.com/ethersphere/bee/issues/1897
+    test.skip('should allow reuploading pinned folder', async () => {
+      const invocation = await invokeTestCli(['upload', 'test', '--pin', ...getStampOption()])
+      const upload = invocation.runnable as Upload
+      const { hash } = upload
+      await invokeTestCli(['pinning', 'reupload', hash])
+      expect(consoleMessages).toHaveLength(4)
+      expect(consoleMessages[3]).toContain('Reuploaded successfully.')
+    })
 
-  it('should print custom 404 when pinning chunk that does not exist', async () => {
-    await invokeTestCli(['pinning', 'pin', 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'])
-    expect(consoleMessages).toHaveLength(2)
-    expect(consoleMessages[0]).toContain(
-      'Could not pin ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
-    )
-    expect(consoleMessages[1]).toContain('No root chunk found with that address.')
-  })
-
-  it('should print custom 404 when unpinning chunk that does not exist', async () => {
-    await invokeTestCli(['pinning', 'unpin', 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'])
-    expect(consoleMessages).toHaveLength(2)
-    expect(consoleMessages[0]).toContain(
-      'Could not unpin ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
-    )
-    expect(consoleMessages[1]).toContain('No pinned chunk found with that address.')
-  })
-
-  // FIXME https://github.com/ethersphere/bee/issues/1897
-  test.skip('should allow reuploading pinned file', async () => {
-    const invocation = await invokeTestCli(['upload', 'README.md', '--pin', ...getStampOption()])
-    const upload = invocation.runnable as Upload
-    const { hash } = upload
-    await invokeTestCli(['pinning', 'reupload', hash])
-    expect(consoleMessages).toHaveLength(4)
-    expect(consoleMessages[3]).toContain('Reuploaded successfully.')
-  })
-
-  // FIXME https://github.com/ethersphere/bee/issues/1897
-  test.skip('should allow reuploading pinned folder', async () => {
-    const invocation = await invokeTestCli(['upload', 'test', '--pin', ...getStampOption()])
-    const upload = invocation.runnable as Upload
-    const { hash } = upload
-    await invokeTestCli(['pinning', 'reupload', hash])
-    expect(consoleMessages).toHaveLength(4)
-    expect(consoleMessages[3]).toContain('Reuploaded successfully.')
-  })
-
-  it('should reupload all pinned content', async () => {
-    await invokeTestCli(['pinning', 'reupload-all'])
-    const last = consoleMessages[consoleMessages.length - 1]
-    expect(last).toMatch(/Reuploaded \d+ out of \d+ pinned chunks/)
-  })
-})
+    it('should reupload all pinned content', async () => {
+      await invokeTestCli(['pinning', 'reupload-all'])
+      const last = consoleMessages[consoleMessages.length - 1]
+      expect(last).toMatch(/Reuploaded \d+ out of \d+ pinned chunks/)
+    })
+  },
+  { configFileName: 'pinning' },
+)

--- a/test/command/pss.spec.ts
+++ b/test/command/pss.spec.ts
@@ -1,26 +1,10 @@
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
 import { Receive } from '../../src/command/pss/receive'
 import { sleep } from '../../src/utils'
-import { invokeTestCli } from '../utility'
+import { describeCommand, invokeTestCli } from '../utility'
 import { getStampOption } from '../utility/stamp'
 
-describe('Test PSS command', () => {
-  const consoleMessages: string[] = []
-  const getLastMessage = () => consoleMessages[consoleMessages.length - 1]
-
-  beforeAll(() => {
-    global.console.log = jest.fn(message => {
-      consoleMessages.push(message)
-    })
-    global.console.error = jest.fn(message => {
-      consoleMessages.push(message)
-    })
-  })
-
-  beforeEach(() => {
-    consoleMessages.length = 0
-  })
-
+describeCommand('Test PSS command', ({ getLastMessage }) => {
   it('should receive sent pss message', async () => {
     const invocation = invokeTestCli([
       'pss',

--- a/test/command/stamp.spec.ts
+++ b/test/command/stamp.spec.ts
@@ -25,7 +25,7 @@ describeCommand('Test Stamp command', ({ consoleMessages, getLastMessage }) => {
   })
 
   it('should buy stamp', async () => {
-    await invokeTestCli(['stamp', 'buy', '--amount', '100', '--depth', '20'])
+    await invokeTestCli(['stamp', 'buy', '--amount', '100000', '--depth', '20'])
     expect(getLastMessage()).toContain('Stamp ID:')
   })
 

--- a/test/command/stamp.spec.ts
+++ b/test/command/stamp.spec.ts
@@ -1,22 +1,6 @@
-import { invokeTestCli } from '../utility'
+import { describeCommand, invokeTestCli } from '../utility'
 
-describe('Test Stamp command', () => {
-  const consoleMessages: string[] = []
-  const getLastMessage = () => consoleMessages[consoleMessages.length - 1]
-
-  beforeAll(() => {
-    global.console.log = jest.fn(message => {
-      consoleMessages.push(message)
-    })
-    global.console.error = jest.fn(message => {
-      consoleMessages.push(message)
-    })
-  })
-
-  beforeEach(() => {
-    consoleMessages.length = 0
-  })
-
+describeCommand('Test Stamp command', ({ consoleMessages, getLastMessage }) => {
   it('should list stamps', async () => {
     await invokeTestCli(['stamp', 'list'])
     expect(consoleMessages[1]).toContain('Stamp ID:')

--- a/test/command/status.spec.ts
+++ b/test/command/status.spec.ts
@@ -1,25 +1,11 @@
 import { createChequeMockHttpServer } from '../http-mock/cheque-mock'
-import { invokeTestCli } from '../utility'
+import { describeCommand, invokeTestCli } from '../utility'
 
-describe('Test Status command', () => {
-  const consoleMessages: string[] = []
+describeCommand('Test Status command', ({ consoleMessages }) => {
   const server = createChequeMockHttpServer(1333)
-
-  beforeAll(() => {
-    global.console.log = jest.fn(message => {
-      consoleMessages.push(message)
-    })
-    global.console.error = jest.fn(message => {
-      consoleMessages.push(message)
-    })
-  })
 
   afterAll(() => {
     server.close()
-  })
-
-  beforeEach(() => {
-    consoleMessages.length = 0
   })
 
   it('should succeed with all checks', async () => {

--- a/test/command/upload.spec.ts
+++ b/test/command/upload.spec.ts
@@ -1,22 +1,8 @@
 import type { Upload } from '../../src/command/upload'
-import { invokeTestCli } from '../utility'
+import { describeCommand, invokeTestCli } from '../utility'
 import { getStampOption } from '../utility/stamp'
 
-describe('Test Upload command', () => {
-  let consoleMessages: string[] = []
-
-  beforeAll(() => {
-    global.console.log = jest.fn(message => {
-      consoleMessages.push(message)
-    })
-    jest.spyOn(global.console, 'warn')
-  })
-
-  beforeEach(() => {
-    //clear stored console messages
-    consoleMessages = []
-  })
-
+describeCommand('Test Upload command', () => {
   it('should upload testpage folder', async () => {
     const commandKey = 'upload'
     const uploadFolderPath = `${__dirname}/../testpage`

--- a/test/misc/config.spec.ts
+++ b/test/misc/config.spec.ts
@@ -1,68 +1,52 @@
 import { writeFileSync } from 'fs'
 import { join } from 'path'
-import { invokeTestCli } from '../utility'
+import { describeCommand, invokeTestCli } from '../utility'
 
-describe('Test configuration loading', () => {
-  let consoleMessages: string[] = []
+describeCommand(
+  'Test configuration loading',
+  ({ consoleMessages, configFolderPath }) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const configFilePath = process.env.SWARM_CLI_CONFIG_FILE_PATH!
 
-  const configFolderPath = join(__dirname, '..', 'testconfig')
-  const configFileName = 'config.config.json'
-  const configFilePath = join(configFolderPath, configFileName)
+    it('should use config when env is not specified', async () => {
+      delete process.env.BEE_DEBUG_API_URL
 
-  beforeAll(() => {
-    global.console.log = jest.fn(message => {
-      consoleMessages.push(message)
+      writeFileSync(
+        configFilePath,
+        JSON.stringify({
+          beeDebugApiUrl: 'http://localhost:30003',
+        }),
+      )
+
+      await invokeTestCli(['cheque', 'list'])
+      expect(consoleMessages[0]).toContain('http://localhost:30003')
     })
-    global.console.error = jest.fn(message => {
-      consoleMessages.push(message)
+
+    it('should use env over config when specified', async () => {
+      process.env.BEE_DEBUG_API_URL = 'http://localhost:30002'
+
+      await invokeTestCli(['cheque', 'list'])
+      expect(consoleMessages[0]).toContain('http://localhost:30002')
     })
-    //set config environment variable
-    process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
-    process.env.SWARM_CLI_CONFIG_FILE = configFileName
-  })
 
-  beforeEach(() => {
-    //clear stored console messages
-    consoleMessages = []
-  })
+    it('should use explicit option over all', async () => {
+      await invokeTestCli(['cheque', 'list', '--bee-debug-api-url', 'http://localhost:30001'])
+      expect(consoleMessages[0]).toContain('http://localhost:30001')
+    })
 
-  it('should use config when env is not specified', async () => {
-    delete process.env.BEE_DEBUG_API_URL
+    it('should read config path explicitly, then use it for url', async () => {
+      delete process.env.BEE_DEBUG_API_URL
 
-    writeFileSync(
-      configFilePath,
-      JSON.stringify({
-        beeDebugApiUrl: 'http://localhost:30003',
-      }),
-    )
+      writeFileSync(
+        join(configFolderPath, 'config2.config.json'),
+        JSON.stringify({
+          beeDebugApiUrl: 'http://localhost:30004',
+        }),
+      )
 
-    await invokeTestCli(['cheque', 'list'])
-    expect(consoleMessages[0]).toContain('http://localhost:30003')
-  })
-
-  it('should use env over config when specified', async () => {
-    process.env.BEE_DEBUG_API_URL = 'http://localhost:30002'
-
-    await invokeTestCli(['cheque', 'list'])
-    expect(consoleMessages[0]).toContain('http://localhost:30002')
-  })
-
-  it('should use explicit option over all', async () => {
-    await invokeTestCli(['cheque', 'list', '--bee-debug-api-url', 'http://localhost:30001'])
-    expect(consoleMessages[0]).toContain('http://localhost:30001')
-  })
-
-  it('should read config path explicitly, then use it for url', async () => {
-    delete process.env.BEE_DEBUG_API_URL
-
-    writeFileSync(
-      join(configFolderPath, 'config2.config.json'),
-      JSON.stringify({
-        beeDebugApiUrl: 'http://localhost:30004',
-      }),
-    )
-
-    await invokeTestCli(['cheque', 'list', '--config-file', 'config2.config.json'])
-    expect(consoleMessages[0]).toContain('http://localhost:30004')
-  })
-})
+      await invokeTestCli(['cheque', 'list', '--config-file', 'config2.config.json'])
+      expect(consoleMessages[0]).toContain('http://localhost:30004')
+    })
+  },
+  { configFileName: 'test-config' },
+)

--- a/test/misc/monetary-units.spec.ts
+++ b/test/misc/monetary-units.spec.ts
@@ -1,31 +1,20 @@
 import { createChequeMockHttpServer } from '../http-mock/cheque-mock'
-import { invokeTestCli } from '../utility'
+import { describeCommand, invokeTestCli } from '../utility'
 
-const server = createChequeMockHttpServer(1378)
-const consoleMessages: string[] = []
+describeCommand('Test Monetary units', ({ consoleMessages }) => {
+  const server = createChequeMockHttpServer(1378)
 
-const containsAllSubstrings = (string: string, substrings: string[]): boolean => {
-  return substrings.every(substring => string.includes(substring))
-}
+  const containsAllSubstrings = (string: string, substrings: string[]): boolean => {
+    return substrings.every(substring => string.includes(substring))
+  }
 
-const substringsPrinted = (substrings: string[]): boolean => {
-  return Boolean(consoleMessages.find(message => containsAllSubstrings(message, substrings)))
-}
+  const substringsPrinted = (substrings: string[]): boolean => {
+    return Boolean(consoleMessages.find(message => containsAllSubstrings(message, substrings)))
+  }
 
-const expectSubstringsPrinted = (...substrings: string[]): void => {
-  expect(substringsPrinted(substrings)).toBe(true)
-}
-
-describe('Test Monetary units', () => {
-  beforeAll(() => {
-    global.console.log = jest.fn(message => {
-      consoleMessages.push(message)
-    })
-  })
-
-  beforeEach(() => {
-    consoleMessages.length = 0
-  })
+  const expectSubstringsPrinted = (...substrings: string[]): void => {
+    expect(substringsPrinted(substrings)).toBe(true)
+  }
 
   afterAll(() => {
     server.close()

--- a/test/prompt/feed-prompt.spec.ts
+++ b/test/prompt/feed-prompt.spec.ts
@@ -1,88 +1,64 @@
-import { existsSync, unlinkSync } from 'fs'
 import inquirer from 'inquirer'
-import { join } from 'path'
-import { invokeTestCli } from '../utility'
+import { describeCommand, invokeTestCli } from '../utility'
 import { getStampOption } from '../utility/stamp'
 
-describe('Using Feed Commands with Prompts', () => {
-  const configFolderPath = join(__dirname, '..', 'testconfig')
-  const configFileName = 'feed-prompt.config.json'
-  const configFilePath = join(configFolderPath, configFileName)
-  const consoleMessages: string[] = []
+describeCommand(
+  'Using Feed Commands with Prompts',
+  ({ consoleMessages, getNthLastMessage, getLastMessage }) => {
+    beforeEach(() => {
+      consoleMessages.length = 0
+    })
 
-  const getNthLastMessage = (n: number) => consoleMessages[consoleMessages.length - n]
-  const getLastMessage = () => consoleMessages[consoleMessages.length - 1]
+    it('feed upload should prompt for stamp, identity and password', async () => {
+      await invokeTestCli(['identity', 'create', 'main', '-P', 'secret'])
+      inquirer.prompt = jest
+        .fn()
+        .mockResolvedValueOnce({ value: getStampOption()[1] })
+        .mockResolvedValueOnce({ value: 'main' })
+        .mockResolvedValueOnce({ value: 'secret' })
+      await invokeTestCli(['feed', 'upload', '-v', 'README.md'])
+      expect(inquirer.prompt).toHaveBeenCalledTimes(3)
+      expect(getLastMessage()).toContain('Successfully uploaded to feed.')
+    })
 
-  jest.spyOn(process, 'exit').mockImplementation(() => {
-    throw new Error('process.exit() was called.')
-  })
+    it('feed upload should prompt for identity when it is misspelled', async () => {
+      inquirer.prompt = jest.fn().mockResolvedValueOnce({ value: 'main' })
+      await invokeTestCli(['feed', 'upload', '-v', 'README.md', '-i', '_main', '-P', 'secret', ...getStampOption()])
+      expect(inquirer.prompt).toHaveBeenCalledTimes(1)
+      expect(getLastMessage()).toContain('Successfully uploaded to feed.')
+    })
 
-  if (existsSync(configFilePath)) {
-    unlinkSync(configFilePath)
-  }
+    it('feed upload should prompt for password when it is not given', async () => {
+      inquirer.prompt = jest.fn().mockResolvedValueOnce({ value: 'secret' })
+      await invokeTestCli(['feed', 'upload', '-v', 'README.md', '-i', 'main', ...getStampOption()])
+      expect(inquirer.prompt).toHaveBeenCalledTimes(1)
+      expect(getLastMessage()).toContain('Successfully uploaded to feed.')
+    })
 
-  global.console.log = jest.fn(message => {
-    consoleMessages.push(message)
-  })
-  global.console.error = jest.fn(message => {
-    consoleMessages.push(message)
-  })
+    it('feed upload should fail when running in quiet mode and stamp is missing', async () => {
+      await invokeTestCli(['feed', 'upload', '-q', 'README.md', '-i', 'main', '-P', 'secret'])
+      expect(getLastMessage()).toContain('Required option not provided: stamp')
+    })
 
-  process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
-  process.env.SWARM_CLI_CONFIG_FILE = configFileName
+    it('feed upload should fail when running in quiet mode and identity is missing', async () => {
+      await invokeTestCli(['feed', 'upload', '-q', 'README.md', '-P', 'secret', ...getStampOption()])
+      expect(getLastMessage()).toContain('Required option not provided: identity')
+    })
 
-  beforeEach(() => {
-    consoleMessages.length = 0
-  })
+    it('feed upload should fail when running in quiet mode and identity is misspelled', async () => {
+      await invokeTestCli(['feed', 'upload', '-q', 'README.md', '-i', '_main', '-P', 'secret', ...getStampOption()])
+      expect(getNthLastMessage(4)).toContain('The provided identity does not exist.')
+    })
 
-  it('feed upload should prompt for stamp, identity and password', async () => {
-    await invokeTestCli(['identity', 'create', 'main', '-P', 'secret'])
-    inquirer.prompt = jest
-      .fn()
-      .mockResolvedValueOnce({ value: getStampOption()[1] })
-      .mockResolvedValueOnce({ value: 'main' })
-      .mockResolvedValueOnce({ value: 'secret' })
-    await invokeTestCli(['feed', 'upload', '-v', 'README.md'])
-    expect(inquirer.prompt).toHaveBeenCalledTimes(3)
-    expect(getLastMessage()).toContain('Successfully uploaded to feed.')
-  })
+    it('feed upload should fail when running in quiet mode and password is wrong', async () => {
+      await invokeTestCli(['feed', 'upload', '-q', 'README.md', '-i', 'main', '-P', '_secret', ...getStampOption()])
+      expect(getLastMessage()).toContain('Key derivation failed - possibly wrong passphrase')
+    })
 
-  it('feed upload should prompt for identity when it is misspelled', async () => {
-    inquirer.prompt = jest.fn().mockResolvedValueOnce({ value: 'main' })
-    await invokeTestCli(['feed', 'upload', '-v', 'README.md', '-i', '_main', '-P', 'secret', ...getStampOption()])
-    expect(inquirer.prompt).toHaveBeenCalledTimes(1)
-    expect(getLastMessage()).toContain('Successfully uploaded to feed.')
-  })
-
-  it('feed upload should prompt for password when it is not given', async () => {
-    inquirer.prompt = jest.fn().mockResolvedValueOnce({ value: 'secret' })
-    await invokeTestCli(['feed', 'upload', '-v', 'README.md', '-i', 'main', ...getStampOption()])
-    expect(inquirer.prompt).toHaveBeenCalledTimes(1)
-    expect(getLastMessage()).toContain('Successfully uploaded to feed.')
-  })
-
-  it('feed upload should fail when running in quiet mode and stamp is missing', async () => {
-    await invokeTestCli(['feed', 'upload', '-q', 'README.md', '-i', 'main', '-P', 'secret'])
-    expect(getLastMessage()).toContain('Required option not provided: stamp')
-  })
-
-  it('feed upload should fail when running in quiet mode and identity is missing', async () => {
-    await invokeTestCli(['feed', 'upload', '-q', 'README.md', '-P', 'secret', ...getStampOption()])
-    expect(getLastMessage()).toContain('Required option not provided: identity')
-  })
-
-  it('feed upload should fail when running in quiet mode and identity is misspelled', async () => {
-    await invokeTestCli(['feed', 'upload', '-q', 'README.md', '-i', '_main', '-P', 'secret', ...getStampOption()])
-    expect(getNthLastMessage(4)).toContain('The provided identity does not exist.')
-  })
-
-  it('feed upload should fail when running in quiet mode and password is wrong', async () => {
-    await invokeTestCli(['feed', 'upload', '-q', 'README.md', '-i', 'main', '-P', '_secret', ...getStampOption()])
-    expect(getLastMessage()).toContain('Key derivation failed - possibly wrong passphrase')
-  })
-
-  it('feed upload should fail when running in quiet mode and password is missing', async () => {
-    await invokeTestCli(['feed', 'upload', '-q', 'README.md', '-i', 'main', ...getStampOption()])
-    expect(getLastMessage()).toContain('There is no password passed for V3 wallet initialization')
-  })
-})
+    it('feed upload should fail when running in quiet mode and password is missing', async () => {
+      await invokeTestCli(['feed', 'upload', '-q', 'README.md', '-i', 'main', ...getStampOption()])
+      expect(getLastMessage()).toContain('There is no password passed for V3 wallet initialization')
+    })
+  },
+  { configFileName: 'feed-prompt' },
+)

--- a/test/quality-of-life/numerical.spec.ts
+++ b/test/quality-of-life/numerical.spec.ts
@@ -2,10 +2,10 @@ import { describeCommand, invokeTestCli } from '../utility'
 
 describeCommand(
   'Specifying Large Numbers',
-  ({ consoleMessages }) => {
+  ({ getLastMessage }) => {
     it('should be possible with underscores and units', async () => {
       await invokeTestCli(['stamp', 'buy', '--amount', '1_000K', '--depth', '16', '--gas-price', '100_000_000'])
-      expect(consoleMessages[consoleMessages.length - 1]).toContain('Stamp ID:')
+      expect(getLastMessage()).toContain('Stamp ID:')
     })
   },
   { configFileName: 'numerical' },

--- a/test/quality-of-life/numerical.spec.ts
+++ b/test/quality-of-life/numerical.spec.ts
@@ -1,23 +1,12 @@
-import { join } from 'path'
-import { invokeTestCli } from '../utility'
+import { describeCommand, invokeTestCli } from '../utility'
 
-describe('Specifying Large Numbers', () => {
-  const configFolderPath = join(__dirname, '..', 'testconfig')
-  const configFileName = 'numerical.config.json'
-  const consoleMessages: string[] = []
-
-  global.console.log = jest.fn(message => {
-    consoleMessages.push(message)
-  })
-  process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
-  process.env.SWARM_CLI_CONFIG_FILE = configFileName
-
-  beforeEach(() => {
-    consoleMessages.length = 0
-  })
-
-  it('should be possible with underscores and units', async () => {
-    await invokeTestCli(['stamp', 'buy', '--amount', '1_000K', '--depth', '16', '--gas-price', '10_000'])
-    expect(consoleMessages[consoleMessages.length - 1]).toContain('Stamp ID:')
-  })
-})
+describeCommand(
+  'Specifying Large Numbers',
+  ({ consoleMessages }) => {
+    it('should be possible with underscores and units', async () => {
+      await invokeTestCli(['stamp', 'buy', '--amount', '1_000K', '--depth', '16', '--gas-price', '10_000'])
+      expect(consoleMessages[consoleMessages.length - 1]).toContain('Stamp ID:')
+    })
+  },
+  { configFileName: 'numerical' },
+)

--- a/test/quality-of-life/numerical.spec.ts
+++ b/test/quality-of-life/numerical.spec.ts
@@ -4,7 +4,7 @@ describeCommand(
   'Specifying Large Numbers',
   ({ consoleMessages }) => {
     it('should be possible with underscores and units', async () => {
-      await invokeTestCli(['stamp', 'buy', '--amount', '1_000K', '--depth', '16', '--gas-price', '10_000'])
+      await invokeTestCli(['stamp', 'buy', '--amount', '1_000K', '--depth', '16', '--gas-price', '100_000_000'])
       expect(consoleMessages[consoleMessages.length - 1]).toContain('Stamp ID:')
     })
   },

--- a/test/quality-of-life/topic.spec.ts
+++ b/test/quality-of-life/topic.spec.ts
@@ -5,7 +5,7 @@ const TOPIC_HEX = '0x052ea901df6cdb4d5b2244ff46d0a4988f208541fe34beadc69906b86b4
 
 describeCommand(
   'Specifying Topics',
-  ({ consoleMessages }) => {
+  ({ consoleMessages, getLastMessage }) => {
     beforeAll(async () => {
       await invokeTestCli(['identity', 'create', 'topic', '-P', 'topic'])
       await invokeTestCli([
@@ -68,17 +68,13 @@ describeCommand(
         'topic',
         ...getStampOption(),
       ])
-      expect(consoleMessages[consoleMessages.length - 1]).toContain(
-        'topic and topic-string are incompatible, please only specify one.',
-      )
+      expect(getLastMessage()).toContain('topic and topic-string are incompatible, please only specify one.')
     })
 
     // TODO: https://github.com/ethersphere/bee/issues/2041
     test.skip('should not be possible with both --topic and --topic-string in pss', async () => {
       await invokeTestCli(['pss', 'receive', '-T', 'Awesome PSS Topic', '-t', TOPIC_HEX, '--timeout', '1'])
-      expect(consoleMessages[consoleMessages.length - 1]).toContain(
-        'topic and topic-string are incompatible, please only specify one.',
-      )
+      expect(getLastMessage()).toContain('topic and topic-string are incompatible, please only specify one.')
     })
   },
   { configFileName: 'topic' },

--- a/test/quality-of-life/topic.spec.ts
+++ b/test/quality-of-life/topic.spec.ts
@@ -1,94 +1,85 @@
-import { existsSync, unlinkSync } from 'fs'
-import { join } from 'path'
-import { invokeTestCli } from '../utility'
+import { describeCommand, invokeTestCli } from '../utility'
 import { getStampOption } from '../utility/stamp'
 
 const TOPIC_HEX = '0x052ea901df6cdb4d5b2244ff46d0a4988f208541fe34beadc69906b86b4b2b29'
 
-describe('Specifying Topics', () => {
-  const configFolderPath = join(__dirname, '..', 'testconfig')
-  const configFileName = 'topic.config.json'
-  const configFilePath = join(configFolderPath, configFileName)
-  const consoleMessages: string[] = []
+describeCommand(
+  'Specifying Topics',
+  ({ consoleMessages }) => {
+    beforeAll(async () => {
+      await invokeTestCli(['identity', 'create', 'topic', '-P', 'topic'])
+      await invokeTestCli([
+        'feed',
+        'upload',
+        '-t',
+        TOPIC_HEX,
+        '-i',
+        'topic',
+        '-P',
+        'topic',
+        '.babelrc.js',
+        ...getStampOption(),
+      ])
+    })
 
-  global.console.log = jest.fn(message => {
-    consoleMessages.push(message)
-  })
-  global.console.error = jest.fn(message => {
-    consoleMessages.push(message)
-  })
+    // TODO: https://github.com/ethersphere/bee/issues/2041
+    test.skip('should be possible with --topic in pss', async () => {
+      await invokeTestCli(['pss', 'receive', '-t', TOPIC_HEX, '--timeout', '1'])
+      expect(consoleMessages[0]).toContain('052ea901df6cdb4d5b2244ff46d0a4988f208541fe34beadc69906b86b4b2b29')
+    })
 
-  if (existsSync(configFilePath)) unlinkSync(configFilePath)
+    // TODO: https://github.com/ethersphere/bee/issues/2041
+    test.skip('should be possible with --topic-string in pss', async () => {
+      await invokeTestCli(['pss', 'receive', '-T', 'Awesome PSS Topic', '--timeout', '1'])
+      expect(consoleMessages[0]).toContain('052ea901df6cdb4d5b2244ff46d0a4988f208541fe34beadc69906b86b4b2b29')
+    })
 
-  process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
-  process.env.SWARM_CLI_CONFIG_FILE = configFileName
+    it('should be possible with --topic in feed', async () => {
+      await invokeTestCli(['feed', 'print', '-t', TOPIC_HEX, '-i', 'topic', '-P', 'topic', ...getStampOption()])
+      expect(consoleMessages[0]).toContain('052ea901df6cdb4d5b2244ff46d0a4988f208541fe34beadc69906b86b4b2b29')
+    })
 
-  beforeEach(() => {
-    consoleMessages.length = 0
-  })
+    it('should be possible with --topic-string in feed', async () => {
+      await invokeTestCli([
+        'feed',
+        'print',
+        '-T',
+        'Awesome PSS Topic',
+        '-i',
+        'topic',
+        '-P',
+        'topic',
+        ...getStampOption(),
+      ])
+      expect(consoleMessages[0]).toContain('052ea901df6cdb4d5b2244ff46d0a4988f208541fe34beadc69906b86b4b2b29')
+    })
 
-  beforeAll(async () => {
-    await invokeTestCli(['identity', 'create', 'topic', '-P', 'topic'])
-    await invokeTestCli([
-      'feed',
-      'upload',
-      '-t',
-      TOPIC_HEX,
-      '-i',
-      'topic',
-      '-P',
-      'topic',
-      '.babelrc.js',
-      ...getStampOption(),
-    ])
-  })
+    it('should not be possible with both --topic and --topic-string in feed', async () => {
+      await invokeTestCli([
+        'feed',
+        'print',
+        '-t',
+        TOPIC_HEX,
+        '-T',
+        'Awesome PSS Topic',
+        '-i',
+        'topic',
+        '-P',
+        'topic',
+        ...getStampOption(),
+      ])
+      expect(consoleMessages[consoleMessages.length - 1]).toContain(
+        'topic and topic-string are incompatible, please only specify one.',
+      )
+    })
 
-  // TODO: https://github.com/ethersphere/bee/issues/2041
-  test.skip('should be possible with --topic in pss', async () => {
-    await invokeTestCli(['pss', 'receive', '-t', TOPIC_HEX, '--timeout', '1'])
-    expect(consoleMessages[0]).toContain('052ea901df6cdb4d5b2244ff46d0a4988f208541fe34beadc69906b86b4b2b29')
-  })
-
-  // TODO: https://github.com/ethersphere/bee/issues/2041
-  test.skip('should be possible with --topic-string in pss', async () => {
-    await invokeTestCli(['pss', 'receive', '-T', 'Awesome PSS Topic', '--timeout', '1'])
-    expect(consoleMessages[0]).toContain('052ea901df6cdb4d5b2244ff46d0a4988f208541fe34beadc69906b86b4b2b29')
-  })
-
-  it('should be possible with --topic in feed', async () => {
-    await invokeTestCli(['feed', 'print', '-t', TOPIC_HEX, '-i', 'topic', '-P', 'topic', ...getStampOption()])
-    expect(consoleMessages[0]).toContain('052ea901df6cdb4d5b2244ff46d0a4988f208541fe34beadc69906b86b4b2b29')
-  })
-
-  it('should be possible with --topic-string in feed', async () => {
-    await invokeTestCli(['feed', 'print', '-T', 'Awesome PSS Topic', '-i', 'topic', '-P', 'topic', ...getStampOption()])
-    expect(consoleMessages[0]).toContain('052ea901df6cdb4d5b2244ff46d0a4988f208541fe34beadc69906b86b4b2b29')
-  })
-
-  it('should not be possible with both --topic and --topic-string in feed', async () => {
-    await invokeTestCli([
-      'feed',
-      'print',
-      '-t',
-      TOPIC_HEX,
-      '-T',
-      'Awesome PSS Topic',
-      '-i',
-      'topic',
-      '-P',
-      'topic',
-      ...getStampOption(),
-    ])
-    expect(consoleMessages[consoleMessages.length - 1]).toContain(
-      'topic and topic-string are incompatible, please only specify one.',
-    )
-  })
-
-  // TODO: https://github.com/ethersphere/bee/issues/2041
-  test.skip('should not be possible with both --topic and --topic-string in pss', async () => {
-    await invokeTestCli(['pss', 'receive', '-T', 'Awesome PSS Topic', '-t', TOPIC_HEX, '--timeout', '1'])
-    expect(consoleMessages[consoleMessages.length - 1]).toContain(
-      'topic and topic-string are incompatible, please only specify one.',
-    )
-  })
-})
+    // TODO: https://github.com/ethersphere/bee/issues/2041
+    test.skip('should not be possible with both --topic and --topic-string in pss', async () => {
+      await invokeTestCli(['pss', 'receive', '-T', 'Awesome PSS Topic', '-t', TOPIC_HEX, '--timeout', '1'])
+      expect(consoleMessages[consoleMessages.length - 1]).toContain(
+        'topic and topic-string are incompatible, please only specify one.',
+      )
+    })
+  },
+  { configFileName: 'topic' },
+)

--- a/test/utility/index.ts
+++ b/test/utility/index.ts
@@ -1,4 +1,6 @@
+import { existsSync, unlinkSync } from 'fs'
 import { cli } from 'furious-commander'
+import { join } from 'path'
 import { optionParameters, rootCommandClasses } from '../../src/config'
 
 export async function invokeTestCli(argv: string[]): ReturnType<typeof cli> {
@@ -9,4 +11,65 @@ export async function invokeTestCli(argv: string[]): ReturnType<typeof cli> {
   })
 
   return commandBuilder
+}
+
+type describeFunctionArgs = {
+  consoleMessages: string[]
+  configFolderPath: string
+  getNthLastMessage: (n: number) => string
+  getLastMessage: () => string
+}
+
+export function describeCommand(
+  description: string,
+  func: (clauseFields: describeFunctionArgs) => void,
+  options?: { configFileName?: string },
+): void {
+  describe(description, () => {
+    const consoleMessages: string[] = []
+    const configFileName = options?.configFileName
+    const configFolderPath = join(__dirname, '..', 'testconfig')
+    const getNthLastMessage = (n: number) => consoleMessages[consoleMessages.length - n]
+    const getLastMessage = () => consoleMessages[consoleMessages.length - 1]
+
+    global.console.log = jest.fn(message => {
+      consoleMessages.push(message)
+    })
+    global.console.error = jest.fn(message => {
+      consoleMessages.push(message)
+    })
+
+    global.console.log = jest.fn(message => {
+      consoleMessages.push(message)
+    })
+    global.console.error = jest.fn(message => {
+      consoleMessages.push(message)
+    })
+
+    jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit() was called.')
+    })
+
+    jest.spyOn(global.console, 'warn')
+
+    //if own config is needed
+    if (configFileName) {
+      const fileName = `${configFileName}.json`
+      const configFilePath = join(configFolderPath, fileName)
+
+      //set config environment variable
+      process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
+      process.env.SWARM_CLI_CONFIG_FILE = fileName
+      process.env.SWARM_CLI_CONFIG_FILE_PATH = configFilePath
+
+      //remove config file if it exists
+      if (existsSync(configFilePath)) unlinkSync(configFilePath)
+    }
+
+    beforeEach(() => {
+      consoleMessages.length = 0
+    })
+
+    func({ consoleMessages, getNthLastMessage, getLastMessage, configFolderPath })
+  })
 }

--- a/test/utility/index.ts
+++ b/test/utility/index.ts
@@ -28,9 +28,12 @@ export function describeCommand(
   describe(description, () => {
     const consoleMessages: string[] = []
     const configFileName = options?.configFileName
-    const configFolderPath = join(__dirname, '..', 'testconfig')
     const getNthLastMessage = (n: number) => consoleMessages[consoleMessages.length - n]
     const getLastMessage = () => consoleMessages[consoleMessages.length - 1]
+    const configFolderPath = join(__dirname, '..', 'testconfig')
+
+    //set config environment variable
+    process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
 
     global.console.log = jest.fn(message => {
       consoleMessages.push(message)
@@ -58,7 +61,6 @@ export function describeCommand(
       const configFilePath = join(configFolderPath, fileName)
 
       //set config environment variable
-      process.env.SWARM_CLI_CONFIG_FOLDER = configFolderPath
       process.env.SWARM_CLI_CONFIG_FILE = fileName
       process.env.SWARM_CLI_CONFIG_FILE_PATH = configFilePath
 


### PR DESCRIPTION
Every test had the same init for console logs and config setups, this PR extract this into the `describeCommand` test utility function to maintain clearer test files.