### PR TITLE
docs: add automation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ swarm-cli upload -q README.md --stamp $STAMP
 ## Config
 
 The configuration file is placed in a hidden folder named `swarm-cli`.
+
 In case of Unix-based systems this config path will be: `$HOME/.swarm-cli`
+
 On Windows systems: `$HOME\AppData\swarm-cli`
 
 The configuration file is saved with `600` file permission.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # Description
 
-> Command line interface tool for manage Bee node and utilize its functionalities
+> Manage your Bee node and interact with the Swarm network via the CLI
 
 The goal of this project is to handle most of the Swarm operations through CLI at some point in the future.
 For currently supported operations, see [Commands](##Commands) section.
@@ -164,6 +164,57 @@ This is also indicated in the `--help` section:
 -T --topic-string  Construct the topic from human readable strings                          [string]
 
 Only one is required: [topic] or [topic-string]
+```
+
+### Automatizing tasks with Swarm-CLI
+
+Running `swarm-cli` with the flag `--quiet` (or `-q` for short) disables all interactive features, and makes commands print information in an easily parsable format. The exit code also indicates whether running the command was successful or not. These may be useful for automatizing tasks both in CI environments and in your terminal too.
+
+Below you will find a few snippets to give an idea how it can be used to compose tasks.
+
+#### Connectivity
+
+Exit if not all status checks succeed:
+
+```
+swarm-cli status -q || exit 1
+```
+
+Check Bee API connection, compatibility does not matter:
+
+```
+swarm-cli status -q | head -n 1 | grep "^OK"
+```
+
+#### Postage Stamps
+
+Grab the first postage stamp:
+
+```
+swarm-cli stamp list -q | head -n 1 | awk '{ print $1 }'
+```
+
+
+List all postage stamps with zero utilization:
+
+```
+swarm-cli stamp list -q | awk '{ if ($2 == 0) print $1 }'
+```
+
+
+Sort postage stamps based on utilization (least utilized comes first):
+
+```
+swarm-cli stamp list -q | sort -k 2
+```
+
+#### Uploading
+
+Upload a file with the least utilized postage stamp:
+
+```
+STAMP=$(swarm-cli stamp list -q | sort -k 2 | head -n 1 | awk '{ print $1 }')
+swarm-cli upload -q README.md --stamp $STAMP
 ```
 
 ## Config

--- a/README.md
+++ b/README.md
@@ -9,6 +9,34 @@
 
 **Warning: This project is in alpha state. There might (and most probably will) be changes in the future to its API and working. Also, no guarantees can be made about its stability, efficiency, and security at this stage.**
 
+# Table of Contents
+
+* [Swarm-CLI](#swarm-cli)
+* [Table of Contents](#table-of-contents)
+* [Description](#description)
+   * [Installation](#installation)
+      * [From npm](#from-npm)
+      * [From source](#from-source)
+   * [Usage](#usage)
+   * [Commands](#commands)
+   * [Example usage](#example-usage)
+   * [Usability Features](#usability-features)
+      * [Numerical Separator and Units](#numerical-separator-and-units)
+      * [Stamp Picker](#stamp-picker)
+      * [Identity Picker](#identity-picker)
+      * [Human Readable Topics](#human-readable-topics)
+      * [Automatizing tasks with Swarm-CLI](#automatizing-tasks-with-swarm-cli)
+         * [Connectivity](#connectivity)
+         * [Postage Stamps](#postage-stamps)
+         * [Uploading](#uploading)
+   * [Config](#config)
+   * [Assignment priority](#assignment-priority)
+   * [System environment](#system-environment)
+* [Development](#development)
+* [Contribute](#contribute)
+* [Maintainers](#maintainers)
+* [License](#license)
+
 # Description
 
 > Manage your Bee node and interact with the Swarm network via the CLI

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
       * [Stamp Picker](#stamp-picker)
       * [Identity Picker](#identity-picker)
       * [Human Readable Topics](#human-readable-topics)
-      * [Automatizing tasks with Swarm-CLI](#automatizing-tasks-with-swarm-cli)
+      * [Automating tasks with Swarm-CLI](#automating-tasks-with-swarm-cli)
          * [Connectivity](#connectivity)
          * [Postage Stamps](#postage-stamps)
          * [Uploading](#uploading)
@@ -194,9 +194,9 @@ This is also indicated in the `--help` section:
 Only one is required: [topic] or [topic-string]
 ```
 
-### Automatizing tasks with Swarm-CLI
+### Automating tasks with Swarm-CLI
 
-Running `swarm-cli` with the flag `--quiet` (or `-q` for short) disables all interactive features, and makes commands print information in an easily parsable format. The exit code also indicates whether running the command was successful or not. These may be useful for automatizing tasks both in CI environments and in your terminal too.
+Running `swarm-cli` with the flag `--quiet` (or `-q` for short) disables all interactive features, and makes commands print information in an easily parsable format. The exit code also indicates whether running the command was successful or not. These may be useful for automating tasks both in CI environments and in your terminal too.
 
 Below you will find a few snippets to give an idea how it can be used to compose tasks.
 

--- a/README.md
+++ b/README.md
@@ -219,11 +219,11 @@ swarm-cli upload -q README.md --stamp $STAMP
 
 ## Config
 
-The configuration file is placed in a hidden folder named swarm-cli.
-In case of Unix-based systems this config path will be: $HOME/.swarm-cli
-On Windows systems: $HOME\AppData\swarm-cli
+The configuration file is placed in a hidden folder named `swarm-cli`.
+In case of Unix-based systems this config path will be: `$HOME/.swarm-cli`
+On Windows systems: `$HOME\AppData\swarm-cli`
 
-The configuration file is saved with 600 file permission.
+The configuration file is saved with `600` file permission.
 
 On first run, this configuration will be generated with default values, that you are able to change on your demand under the before mentioned path.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Running `swarm-cli` without arguments prints the available commands:
 
 ```
 $ swarm-cli
-Swarm CLI 0.9.0 - Manage your Bee node and interact with the Swarm network via the CLI
+Swarm CLI 0.10.0 - Manage your Bee node and interact with the Swarm network via the CLI
 
 █ Usage:
 
@@ -90,6 +90,7 @@ Run 'swarm-cli GROUP --help' to see available commands in a group
 █ Available Commands:
 
 upload   Upload file to Swarm
+status   Check API availability and Bee compatibility
 
 Run 'swarm-cli COMMAND --help' for more information on a command
 

--- a/src/command/root-command/printer.ts
+++ b/src/command/root-command/printer.ts
@@ -9,7 +9,7 @@ export const Printer = {
     console.log(char.repeat(process.stdout.columns))
   },
   error: (message: string, ...args: unknown[]): void => {
-    console.log(bold().white().bgRed(message), ...args)
+    console.error(bold().white().bgRed(message), ...args)
   },
   log: (message: string, ...args: unknown[]): void => {
     console.log(message, ...args)

--- a/src/command/status.ts
+++ b/src/command/status.ts
@@ -29,7 +29,7 @@ export class Status extends RootCommand implements LeafCommand {
       await this.bee.checkConnection()
       this.printSuccessfulCheck('Bee API Connection')
     } catch {
-      this.printFailedCheck('Bee API Connection')
+      this.handleFailedCheck('Bee API Connection')
     }
   }
 
@@ -40,7 +40,7 @@ export class Status extends RootCommand implements LeafCommand {
 
       return health.version
     } catch {
-      this.printFailedCheck('Bee Debug API Connection')
+      this.handleFailedCheck('Bee Debug API Connection')
 
       return 'N/A'
     }
@@ -53,10 +53,10 @@ export class Status extends RootCommand implements LeafCommand {
       if (compatible) {
         this.printSuccessfulCheck('Bee Version Compatibility')
       } else {
-        this.printFailedCheck('Bee Version Compatibility')
+        this.handleFailedCheck('Bee Version Compatibility')
       }
     } catch {
-      this.printFailedCheck('Bee Version Compatibility')
+      this.handleFailedCheck('Bee Version Compatibility')
     }
   }
 
@@ -65,8 +65,9 @@ export class Status extends RootCommand implements LeafCommand {
     this.console.quiet('OK - ' + message)
   }
 
-  private printFailedCheck(message: string): void {
+  private handleFailedCheck(message: string): void {
     this.console.log(bold(red('[FAILED]')) + ' ' + message)
     this.console.quiet('FAILED - ' + message)
+    process.exitCode = 1
   }
 }


### PR DESCRIPTION
[Preview the README](https://github.com/ethersphere/swarm-cli/blob/98dcb2cf0ad806d6e38653c75dad0d6f8c13f182/README.md)

- Fixes writing errors to stderr
- Sets exit code to `1` when `status` has failures
- Changes description tagline to match Swarm-CLI tagline
- Adds Automation section 
- Adds Table of Contents