### PR TITLE
feat: add upload size prompt/warning/flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ dist
 
 # Dependency directory
 node_modules
+
+# Test data
+test/data/*
+!test/data/.gitkeep

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,6 +6,8 @@ import type { Config } from '@jest/types'
 import { buyStamp } from './test/utility/stamp'
 
 export default async (): Promise<Config.InitialOptions> => {
+  process.env.MAX_UPLOAD_SIZE = '5000000' // 5 megabytes
+
   if (!process.env.STAMP) {
     process.env.STAMP = await buyStamp()
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "cli-progress": "^3.8.2",
         "ethereumjs-wallet": "^1.0.1",
         "furious-commander": "1.3.0",
-        "get-folder-size": "^3.1.0",
         "inquirer": "^7.3.3",
         "kleur": "^4.1.4",
         "ora": "^5.3.0"
@@ -32,7 +31,6 @@
         "@commitlint/config-conventional": "^11.0.0",
         "@types/cli-progress": "^3.8.0",
         "@types/configstore": "^4.0.0",
-        "@types/get-folder-size": "^3.0.0",
         "@types/glob": "^7.1.3",
         "@types/inquirer": "^7.3.1",
         "@types/jest": "^26.0.19",
@@ -2814,15 +2812,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
       "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
       "dev": true
-    },
-    "node_modules/@types/get-folder-size": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/get-folder-size/-/get-folder-size-3.0.0.tgz",
-      "integrity": "sha512-h2y9/Z34T5G12bS4ntpC1wFMqUdnw9PC5MaU7rOZEFqwKyqv8W1tmRKSZzvfZR5f6c8xgXHRko3X0BFJhdUkHA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/glob": {
       "version": "7.1.3",
@@ -6320,11 +6309,6 @@
         "npm": ">=6.0.0"
       }
     },
-    "node_modules/gar": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
-      "integrity": "sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w=="
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -6341,20 +6325,6 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-folder-size": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-3.1.0.tgz",
-      "integrity": "sha512-/I7q+x1HCd22IXP4+kp2Wkz8+au7VfNwNyMfM4Z0gwaTMs+dJ1ShXUWDGSWXi+rDU59MI/j7NBP7+kd7zejnPw==",
-      "dependencies": {
-        "gar": "^1.0.4"
-      },
-      "bin": {
-        "get-folder-size": "bin/get-folder-size.js"
-      },
-      "engines": {
-        "node": ">=14.13.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -12349,10 +12319,7 @@
     "node_modules/tar-js": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/tar-js/-/tar-js-0.3.0.tgz",
-      "integrity": "sha1-aUmqv7C6GLsVYq5RpDn9DzAYOhc=",
-      "engines": {
-        "node": "*"
-      }
+      "integrity": "sha1-aUmqv7C6GLsVYq5RpDn9DzAYOhc="
     },
     "node_modules/terminal-link": {
       "version": "2.1.1",
@@ -15881,15 +15848,6 @@
       "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
       "dev": true
     },
-    "@types/get-folder-size": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/get-folder-size/-/get-folder-size-3.0.0.tgz",
-      "integrity": "sha512-h2y9/Z34T5G12bS4ntpC1wFMqUdnw9PC5MaU7rOZEFqwKyqv8W1tmRKSZzvfZR5f6c8xgXHRko3X0BFJhdUkHA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -18617,11 +18575,6 @@
         "reflect-metadata": "^0.1.13"
       }
     },
-    "gar": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
-      "integrity": "sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w=="
-    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -18633,14 +18586,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
-    },
-    "get-folder-size": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-3.1.0.tgz",
-      "integrity": "sha512-/I7q+x1HCd22IXP4+kp2Wkz8+au7VfNwNyMfM4Z0gwaTMs+dJ1ShXUWDGSWXi+rDU59MI/j7NBP7+kd7zejnPw==",
-      "requires": {
-        "gar": "^1.0.4"
-      }
     },
     "get-intrinsic": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cli-progress": "^3.8.2",
         "ethereumjs-wallet": "^1.0.1",
         "furious-commander": "1.3.0",
+        "get-folder-size": "^3.1.0",
         "inquirer": "^7.3.3",
         "kleur": "^4.1.4",
         "ora": "^5.3.0"
@@ -31,6 +32,7 @@
         "@commitlint/config-conventional": "^11.0.0",
         "@types/cli-progress": "^3.8.0",
         "@types/configstore": "^4.0.0",
+        "@types/get-folder-size": "^3.0.0",
         "@types/glob": "^7.1.3",
         "@types/inquirer": "^7.3.1",
         "@types/jest": "^26.0.19",
@@ -2812,6 +2814,15 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
       "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
       "dev": true
+    },
+    "node_modules/@types/get-folder-size": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/get-folder-size/-/get-folder-size-3.0.0.tgz",
+      "integrity": "sha512-h2y9/Z34T5G12bS4ntpC1wFMqUdnw9PC5MaU7rOZEFqwKyqv8W1tmRKSZzvfZR5f6c8xgXHRko3X0BFJhdUkHA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/glob": {
       "version": "7.1.3",
@@ -6309,6 +6320,11 @@
         "npm": ">=6.0.0"
       }
     },
+    "node_modules/gar": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
+      "integrity": "sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w=="
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -6325,6 +6341,20 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-folder-size": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-3.1.0.tgz",
+      "integrity": "sha512-/I7q+x1HCd22IXP4+kp2Wkz8+au7VfNwNyMfM4Z0gwaTMs+dJ1ShXUWDGSWXi+rDU59MI/j7NBP7+kd7zejnPw==",
+      "dependencies": {
+        "gar": "^1.0.4"
+      },
+      "bin": {
+        "get-folder-size": "bin/get-folder-size.js"
+      },
+      "engines": {
+        "node": ">=14.13.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -15851,6 +15881,15 @@
       "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
       "dev": true
     },
+    "@types/get-folder-size": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/get-folder-size/-/get-folder-size-3.0.0.tgz",
+      "integrity": "sha512-h2y9/Z34T5G12bS4ntpC1wFMqUdnw9PC5MaU7rOZEFqwKyqv8W1tmRKSZzvfZR5f6c8xgXHRko3X0BFJhdUkHA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -18578,6 +18617,11 @@
         "reflect-metadata": "^0.1.13"
       }
     },
+    "gar": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
+      "integrity": "sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w=="
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -18589,6 +18633,14 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-folder-size": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-3.1.0.tgz",
+      "integrity": "sha512-/I7q+x1HCd22IXP4+kp2Wkz8+au7VfNwNyMfM4Z0gwaTMs+dJ1ShXUWDGSWXi+rDU59MI/j7NBP7+kd7zejnPw==",
+      "requires": {
+        "gar": "^1.0.4"
+      }
     },
     "get-intrinsic": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@commitlint/config-conventional": "^11.0.0",
     "@types/cli-progress": "^3.8.0",
     "@types/configstore": "^4.0.0",
-    "@types/get-folder-size": "^3.0.0",
     "@types/glob": "^7.1.3",
     "@types/inquirer": "^7.3.1",
     "@types/jest": "^26.0.19",
@@ -76,7 +75,6 @@
     "cli-progress": "^3.8.2",
     "ethereumjs-wallet": "^1.0.1",
     "furious-commander": "1.3.0",
-    "get-folder-size": "^3.1.0",
     "inquirer": "^7.3.3",
     "kleur": "^4.1.4",
     "ora": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@commitlint/config-conventional": "^11.0.0",
     "@types/cli-progress": "^3.8.0",
     "@types/configstore": "^4.0.0",
+    "@types/get-folder-size": "^3.0.0",
     "@types/glob": "^7.1.3",
     "@types/inquirer": "^7.3.1",
     "@types/jest": "^26.0.19",
@@ -75,6 +76,7 @@
     "cli-progress": "^3.8.2",
     "ethereumjs-wallet": "^1.0.1",
     "furious-commander": "1.3.0",
+    "get-folder-size": "^3.1.0",
     "inquirer": "^7.3.3",
     "kleur": "^4.1.4",
     "ora": "^5.3.0"

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -3,7 +3,6 @@ import { Presets, SingleBar } from 'cli-progress'
 import * as FS from 'fs'
 import { readFileSync } from 'fs'
 import { Argument, LeafCommand, Option } from 'furious-commander'
-import getFolderSize from 'get-folder-size'
 import inquirer from 'inquirer'
 import { bold, green } from 'kleur'
 import ora from 'ora'
@@ -279,7 +278,7 @@ export class Upload extends RootCommand implements LeafCommand {
     isDirectory: boolean
   }> {
     const stats = FS.lstatSync(this.path)
-    const size = stats.isDirectory() ? await getFolderSize.loose(this.path) : stats.size
+    const size = stats.isDirectory() ? await this.bee.getFolderSize(this.path) : stats.size
     this.console.verbose('Upload size is approximately ' + (size / 1000 / 1000).toFixed(2) + ' megabytes')
 
     return {

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -14,7 +14,7 @@ import { stampProperties } from '../utils/option'
 import { RootCommand } from './root-command'
 import { VerbosityLevel } from './root-command/command-log'
 
-const MAX_SIZE = 100 * 1000 * 1000 // 100 megabytes
+const MAX_UPLOAD_SIZE = parseInt(process.env.MAX_UPLOAD_SIZE || '', 10) || 100 * 1000 * 1000 // 100 megabytes
 
 export class Upload extends RootCommand implements LeafCommand {
   // CLI FIELDS
@@ -251,7 +251,7 @@ export class Upload extends RootCommand implements LeafCommand {
     }
     const { size, isDirectory } = await this.getUploadableInfo()
 
-    if (size < MAX_SIZE) {
+    if (size < MAX_UPLOAD_SIZE) {
       return
     }
 

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -1,4 +1,4 @@
-import { Tag } from '@ethersphere/bee-js'
+import { Tag, Utils } from '@ethersphere/bee-js'
 import { Presets, SingleBar } from 'cli-progress'
 import * as FS from 'fs'
 import { readFileSync } from 'fs'
@@ -278,7 +278,7 @@ export class Upload extends RootCommand implements LeafCommand {
     isDirectory: boolean
   }> {
     const stats = FS.lstatSync(this.path)
-    const size = stats.isDirectory() ? await this.bee.getFolderSize(this.path) : stats.size
+    const size = stats.isDirectory() ? await Utils.Collections.getFolderSize(this.path) : stats.size
     this.console.verbose('Upload size is approximately ' + (size / 1000 / 1000).toFixed(2) + ' megabytes')
 
     return {

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -3,6 +3,8 @@ import { Presets, SingleBar } from 'cli-progress'
 import * as FS from 'fs'
 import { readFileSync } from 'fs'
 import { Argument, LeafCommand, Option } from 'furious-commander'
+import getFolderSize from 'get-folder-size'
+import inquirer from 'inquirer'
 import { bold, green } from 'kleur'
 import ora from 'ora'
 import { basename, join } from 'path'
@@ -12,6 +14,8 @@ import { fileExists, isGateway, sleep } from '../utils'
 import { stampProperties } from '../utils/option'
 import { RootCommand } from './root-command'
 import { VerbosityLevel } from './root-command/command-log'
+
+const MAX_SIZE = 100 * 1000 * 1000 // 100 megabytes
 
 export class Upload extends RootCommand implements LeafCommand {
   // CLI FIELDS
@@ -30,6 +34,14 @@ export class Upload extends RootCommand implements LeafCommand {
 
   @Option({ key: 'pin', type: 'boolean', description: 'Persist the uploaded data on the node' })
   public pin!: boolean
+
+  @Option({
+    key: 'size-check',
+    type: 'boolean',
+    description: 'Check for optimal file or folder sizes before uploading',
+    default: true,
+  })
+  public sizeCheck!: boolean
 
   @Option({
     key: 'skip-sync',
@@ -107,6 +119,8 @@ export class Upload extends RootCommand implements LeafCommand {
       exit(1)
     }
 
+    await this.maybeRunSizeChecks()
+
     const spinner: ora.Ora = ora('Uploading files...')
 
     if (this.verbosity !== VerbosityLevel.Quiet) {
@@ -114,7 +128,7 @@ export class Upload extends RootCommand implements LeafCommand {
     }
 
     try {
-      if (FS.lstatSync(this.path).isDirectory()) {
+      if (FS.statSync(this.path).isDirectory()) {
         url = await this.uploadFolder(this.stamp, tag)
       } else {
         url = await this.uploadSingleFileAsFileList(this.stamp, tag)
@@ -229,6 +243,48 @@ export class Upload extends RootCommand implements LeafCommand {
       this.console.dim('Data has been synced on Swarm network')
 
       return true
+    }
+  }
+
+  private async maybeRunSizeChecks(): Promise<void> {
+    if (!this.sizeCheck) {
+      return
+    }
+    const { size, isDirectory } = await this.getUploadableInfo()
+
+    if (size < MAX_SIZE) {
+      return
+    }
+
+    const message = `${isDirectory ? 'Folder' : 'File'} size is larger than recommended value.`
+
+    if (this.quiet) {
+      this.console.error(message)
+      this.console.error('Pass --size-check false to ignore this warning.')
+      exit(1)
+    }
+    const { value } = await inquirer.prompt({
+      type: 'confirm',
+      name: 'value',
+      message: message + ' Do you want to proceed?',
+    })
+
+    if (!value) {
+      exit(1)
+    }
+  }
+
+  private async getUploadableInfo(): Promise<{
+    size: number
+    isDirectory: boolean
+  }> {
+    const stats = FS.lstatSync(this.path)
+    const size = stats.isDirectory() ? await getFolderSize.loose(this.path) : stats.size
+    this.console.verbose('Upload size is approximately ' + (size / 1000 / 1000).toFixed(2) + ' megabytes')
+
+    return {
+      size,
+      isDirectory: stats.isDirectory(),
     }
   }
 }

--- a/test/command/upload.spec.ts
+++ b/test/command/upload.spec.ts
@@ -1,8 +1,16 @@
+import { existsSync, unlinkSync, writeFileSync } from 'fs'
+import inquirer from 'inquirer'
 import type { Upload } from '../../src/command/upload'
 import { describeCommand, invokeTestCli } from '../utility'
 import { getStampOption } from '../utility/stamp'
 
-describeCommand('Test Upload command', () => {
+describeCommand('Test Upload command', ({ consoleMessages, getNthLastMessage }) => {
+  if (existsSync('test/data/8mb.bin')) {
+    unlinkSync('test/data/8mb.bin')
+  }
+
+  writeFileSync('test/data/8mb.bin', Buffer.alloc(8_000_000))
+
   it('should upload testpage folder', async () => {
     const commandKey = 'upload'
     const uploadFolderPath = `${__dirname}/../testpage`
@@ -21,5 +29,37 @@ describeCommand('Test Upload command', () => {
     expect(commandBuilder.initedCommands[0].command.name).toBe('upload')
     const command = commandBuilder.initedCommands[0].command as Upload
     expect(command.hash?.length).toBe(64)
+  })
+
+  it('should warn for large files', async () => {
+    inquirer.prompt = jest.fn().mockResolvedValueOnce({ value: false })
+    await invokeTestCli(['upload', 'test/data/8mb.bin', ...getStampOption()])
+    expect(inquirer.prompt).toHaveBeenCalledTimes(1)
+  })
+
+  it('should warn for large folders', async () => {
+    inquirer.prompt = jest.fn().mockResolvedValueOnce({ value: false })
+    await invokeTestCli(['upload', 'test/data', ...getStampOption()])
+    expect(inquirer.prompt).toHaveBeenCalledTimes(1)
+  })
+
+  it('should fail for large files in quiet mode', async () => {
+    await invokeTestCli(['upload', 'test/data/8mb.bin', '--quiet', ...getStampOption()])
+    expect(consoleMessages[0]).toContain('File size is larger than recommended value')
+  })
+
+  it('should fail for large folders in quiet mode', async () => {
+    await invokeTestCli(['upload', 'test/data', '--quiet', ...getStampOption()])
+    expect(consoleMessages[0]).toContain('Folder size is larger than recommended value')
+  })
+
+  it('should not warn for large files with flag', async () => {
+    await invokeTestCli(['upload', 'test/data/8mb.bin', '-v', '--size-check', 'false', ...getStampOption()])
+    expect(getNthLastMessage(2)).toContain('Uploading was successful!')
+  })
+
+  it('should not warn for large folders with flag', async () => {
+    await invokeTestCli(['upload', 'test/data', '-v', '--size-check', 'false', ...getStampOption()])
+    expect(getNthLastMessage(2)).toContain('Uploading was successful!')
   })
 })


### PR DESCRIPTION
In `--verbose` mode, file or folder size is printed before uploading:

```
Upload size is approximately 2.00 megabytes
```

---

When upload size is too large:

```
? Folder size is larger than recommended value. Do you want to proceed? (Y/n) 
```

---

Fails in `--quiet` mode without explicit flag:

```
swarm-cli upload dist -q --stamp ...
Folder size is larger than recommended value.
Pass --size-check false to ignore this warning.
```

---

Needs to be disabled with `--size-check false`