### PR TITLE
feat: add addresses command

### DIFF
--- a/src/command/addresses.ts
+++ b/src/command/addresses.ts
@@ -1,0 +1,36 @@
+import { LeafCommand } from 'furious-commander'
+import { bold, green } from 'kleur'
+import { RootCommand } from './root-command'
+
+export class Addresses extends RootCommand implements LeafCommand {
+  public readonly name = 'addresses'
+
+  public readonly description = 'Display the addresses of the Bee node'
+
+  public async run(): Promise<void> {
+    super.init()
+
+    const nodeAddresses = await this.beeDebug.getNodeAddresses()
+    const chequebookAddress = await this.beeDebug.getChequebookAddress()
+
+    const longest = 'PSS Public Key: '.length
+    this.console.log(bold('Node Addresses'))
+    this.console.divider()
+    this.console.log(green('Ethereum: '.padEnd(longest)) + nodeAddresses.ethereum)
+    this.console.log(green('Overlay: '.padEnd(longest)) + nodeAddresses.overlay)
+    this.console.log(green('PSS Public Key: ') + nodeAddresses.pssPublicKey)
+    this.console.log(green('Public Key: '.padEnd(longest)) + nodeAddresses.publicKey)
+    this.console.log(green('Underlay: '.padEnd(longest)) + nodeAddresses.underlay)
+    this.console.log('')
+    this.console.log(bold('Chequebook Address'))
+    this.console.divider()
+    this.console.log(chequebookAddress.chequebookAddress)
+
+    this.console.quiet('Ethereum ' + nodeAddresses.ethereum)
+    this.console.quiet('Overlay ' + nodeAddresses.overlay)
+    this.console.quiet('PSS_Public_Key ' + nodeAddresses.pssPublicKey)
+    this.console.quiet('Public_Key ' + nodeAddresses.publicKey)
+    this.console.quiet('Underlay ' + nodeAddresses.underlay)
+    this.console.quiet('Chequebook ' + chequebookAddress.chequebookAddress)
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { IOption } from 'furious-commander'
 import PackageJson from '../package.json'
+import { Addresses } from './command/addresses'
 import { Cheque } from './command/cheque'
 import { Feed } from './command/feed'
 import { Identity } from './command/identity'
@@ -82,4 +83,4 @@ export const optionParameters: IOption<unknown>[] = [
   version,
 ]
 
-export const rootCommandClasses = [Upload, Status, Pinning, Identity, Feed, Cheque, Stamp, Pss]
+export const rootCommandClasses = [Upload, Status, Pinning, Identity, Feed, Cheque, Stamp, Pss, Addresses]

--- a/test/command/addresses.spec.ts
+++ b/test/command/addresses.spec.ts
@@ -1,0 +1,27 @@
+import { describeCommand, invokeTestCli } from '../utility'
+
+describeCommand(
+  'Test Addresses command',
+  ({ consoleMessages }) => {
+    it('should print addresses', async () => {
+      await invokeTestCli(['addresses'])
+      expect(consoleMessages[2]).toMatch(/0x[0-9a-f]{10}/i)
+      expect(consoleMessages[3]).toMatch(/[0-9a-f]{10}/i)
+      expect(consoleMessages[4]).toMatch(/[0-9a-f]{10}/i)
+      expect(consoleMessages[5]).toMatch(/[0-9a-f]{10}/i)
+      expect(consoleMessages[6]).toContain('/ip4/')
+      expect(consoleMessages[10]).toMatch(/0x[0-9a-f]{10}/i)
+    })
+
+    it('should be splittable in quiet mode', async () => {
+      await invokeTestCli(['addresses', '-q'])
+      expect(consoleMessages[0].split(' ')[1]).toMatch(/0x[0-9a-f]{10}/i)
+      expect(consoleMessages[1].split(' ')[1]).toMatch(/[0-9a-f]{10}/i)
+      expect(consoleMessages[2].split(' ')[1]).toMatch(/[0-9a-f]{10}/i)
+      expect(consoleMessages[3].split(' ')[1]).toMatch(/[0-9a-f]{10}/i)
+      expect(consoleMessages[4].split(' ')[1]).toContain('/ip4/')
+      expect(consoleMessages[5].split(' ')[1]).toMatch(/0x[0-9a-f]{10}/i)
+    })
+  },
+  { configFileName: 'addresses' },
+)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/77121044/122371230-fdb0d780-cf5f-11eb-8f65-fd41abd09c62.png)

![image](https://user-images.githubusercontent.com/77121044/122371265-07d2d600-cf60-11eb-82d4-d1b981fec9e6.png)

The idea for `--quiet` mode is that `awk { print $2 }` would always be the address