### PR TITLE
feat: add --drop-name to upload, print stamp after usage, sync progress

### DIFF
--- a/src/command/feed/feed-command.ts
+++ b/src/command/feed/feed-command.ts
@@ -5,7 +5,7 @@ import { bold, green } from 'kleur'
 import { exit } from 'process'
 import { getWalletFromIdentity, pickIdentity } from '../../service/identity'
 import { Identity } from '../../service/identity/types'
-import { enrichStamp, printStamp } from '../../service/stamp'
+import { printEnrichedStamp } from '../../service/stamp'
 import { stampProperties, topicProperties, topicStringProperties } from '../../utils/option'
 import { RootCommand } from '../root-command'
 
@@ -47,7 +47,7 @@ export class FeedCommand extends RootCommand {
 
     this.console.quiet(manifest)
 
-    printStamp(enrichStamp(await this.bee.getPostageBatch(this.stamp)), this.console)
+    printEnrichedStamp(await this.bee.getPostageBatch(this.stamp), this.console)
     this.console.divider()
   }
 

--- a/src/command/feed/feed-command.ts
+++ b/src/command/feed/feed-command.ts
@@ -5,6 +5,7 @@ import { bold, green } from 'kleur'
 import { exit } from 'process'
 import { getWalletFromIdentity, pickIdentity } from '../../service/identity'
 import { Identity } from '../../service/identity/types'
+import { enrichStamp, printStamp } from '../../service/stamp'
 import { stampProperties, topicProperties, topicStringProperties } from '../../utils/option'
 import { RootCommand } from '../root-command'
 
@@ -45,6 +46,9 @@ export class FeedCommand extends RootCommand {
     this.console.log(bold(`Feed Manifest URL -> ${green(`${this.beeApiUrl}/bzz/${manifest}/`)}`))
 
     this.console.quiet(manifest)
+
+    printStamp(enrichStamp(await this.bee.getPostageBatch(this.stamp)), this.console)
+    this.console.divider()
   }
 
   protected async getWallet(): Promise<Wallet> {

--- a/src/command/feed/feed-command.ts
+++ b/src/command/feed/feed-command.ts
@@ -48,7 +48,6 @@ export class FeedCommand extends RootCommand {
     this.console.quiet(manifest)
 
     printEnrichedStamp(await this.bee.getPostageBatch(this.stamp), this.console)
-    this.console.divider()
   }
 
   protected async getWallet(): Promise<Wallet> {

--- a/src/command/feed/upload.ts
+++ b/src/command/feed/upload.ts
@@ -26,9 +26,7 @@ export class Upload extends FeedCommand implements LeafCommand {
   }
 
   private async runUpload(): Promise<string> {
-    this.fileUpload.usedFromOtherCommand = true
-
-    await this.fileUpload.run()
+    await this.fileUpload.run(true)
 
     return this.fileUpload.hash
   }

--- a/src/command/stamp/list.ts
+++ b/src/command/stamp/list.ts
@@ -1,5 +1,5 @@
 import { LeafCommand, Option } from 'furious-commander'
-import { enrichStamp } from '../../service/stamp'
+import { enrichStamp, printStamp } from '../../service/stamp'
 import { StampCommand } from './stamp-command'
 
 export class List extends StampCommand implements LeafCommand {
@@ -62,6 +62,6 @@ export class List extends StampCommand implements LeafCommand {
     const limitedStamps = filteredStamps.slice(0, this.limit)
 
     const orderedStamps = this.leastUsed ? limitedStamps.sort((a, b) => a.usage - b.usage) : limitedStamps
-    orderedStamps.forEach(stamp => this.printStamp(stamp))
+    orderedStamps.forEach(stamp => printStamp(stamp, this.console))
   }
 }

--- a/src/command/stamp/show.ts
+++ b/src/command/stamp/show.ts
@@ -1,5 +1,5 @@
 import { Argument, LeafCommand } from 'furious-commander'
-import { enrichStamp, pickStamp } from '../../service/stamp'
+import { enrichStamp, pickStamp, printStamp } from '../../service/stamp'
 import { stampProperties } from '../../utils/option'
 import { StampCommand } from './stamp-command'
 
@@ -22,6 +22,6 @@ export class Show extends StampCommand implements LeafCommand {
 
     const stamp = await this.bee.getPostageBatch(this.stamp)
 
-    this.printStamp(enrichStamp(stamp))
+    printStamp(enrichStamp(stamp), this.console)
   }
 }

--- a/src/command/stamp/show.ts
+++ b/src/command/stamp/show.ts
@@ -1,5 +1,5 @@
 import { Argument, LeafCommand } from 'furious-commander'
-import { enrichStamp, pickStamp, printStamp } from '../../service/stamp'
+import { pickStamp, printEnrichedStamp } from '../../service/stamp'
 import { stampProperties } from '../../utils/option'
 import { StampCommand } from './stamp-command'
 
@@ -22,6 +22,6 @@ export class Show extends StampCommand implements LeafCommand {
 
     const stamp = await this.bee.getPostageBatch(this.stamp)
 
-    printStamp(enrichStamp(stamp), this.console)
+    printEnrichedStamp(stamp, this.console)
   }
 }

--- a/src/command/stamp/stamp-command.ts
+++ b/src/command/stamp/stamp-command.ts
@@ -1,22 +1,7 @@
 import { bold } from 'kleur'
-import { EnrichedStamp } from '../../service/stamp/types/stamp'
 import { RootCommand } from '../root-command'
 
 export class StampCommand extends RootCommand {
-  protected printStamp(stamp: EnrichedStamp): void {
-    this.console.divider('-')
-    this.console.log(bold('Stamp ID: ') + stamp.batchID)
-    this.console.log(bold('Usage: ') + stamp.usageText)
-    this.console.verbose(bold('Depth: ') + stamp.depth)
-    this.console.verbose(bold('Bucket depth: ') + stamp.bucketDepth)
-    this.console.verbose(bold('Amount: ') + stamp.amount)
-    this.console.verbose(bold('Usable: ') + stamp.usable)
-    this.console.verbose(bold('Utilization: ') + stamp.utilization)
-    this.console.verbose(bold('Block Number: ') + stamp.blockNumber)
-    this.console.verbose(bold('Immutable Flag: ') + stamp.immutableFlag)
-    this.console.quiet(stamp.batchID + ' ' + stamp.usageText)
-  }
-
   protected printBatchId(batchId: string): void {
     this.console.log(bold('Stamp ID: ') + batchId)
     this.console.quiet(batchId)

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -52,7 +52,7 @@ export class Upload extends RootCommand implements LeafCommand {
   @Option({
     key: 'drop-name',
     type: 'boolean',
-    description: 'Erase file name when upliading a single file',
+    description: 'Erase file name when uploading a single file',
   })
   public dropName!: boolean
 

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -192,7 +192,7 @@ export class Upload extends RootCommand implements LeafCommand {
   }
 
   private async uploadSingleFile(postageBatchId: string, tag?: Tag): Promise<string> {
-    const readable = FS.createReadStream(this.path)
+    const readable = FS.readFileSync(this.path)
     const parsedPath = parse(this.path)
     this.hash = await this.bee.uploadFile(postageBatchId, readable, this.keepName ? parsedPath.base : undefined, {
       tag: tag && tag.uid,
@@ -223,9 +223,9 @@ export class Upload extends RootCommand implements LeafCommand {
     for (let i = 0; i < pollingTrials; i++) {
       tag = await this.bee.retrieveTag(tagUid)
 
-      if (syncStatus !== tag.processed) {
+      if (syncStatus !== tag.synced) {
         i = 0
-        syncStatus = tag.processed
+        syncStatus = tag.synced
       }
       progressBar.update(syncStatus)
 

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -7,7 +7,7 @@ import { bold, green } from 'kleur'
 import ora from 'ora'
 import { join, parse } from 'path'
 import { exit } from 'process'
-import { enrichStamp, pickStamp, printStamp } from '../service/stamp'
+import { pickStamp, printEnrichedStamp } from '../service/stamp'
 import { fileExists, isGateway, sleep } from '../utils'
 import { stampProperties } from '../utils/option'
 import { RootCommand } from './root-command'
@@ -164,7 +164,7 @@ export class Upload extends RootCommand implements LeafCommand {
 
     if (!this.usedFromOtherCommand) {
       this.console.quiet(this.hash)
-      printStamp(enrichStamp(await this.bee.getPostageBatch(this.stamp)), this.console)
+      printEnrichedStamp(await this.bee.getPostageBatch(this.stamp), this.console)
       this.console.divider()
     }
   }

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -163,7 +163,6 @@ export class Upload extends RootCommand implements LeafCommand {
     if (!usedFromOtherCommand) {
       this.console.quiet(this.hash)
       printEnrichedStamp(await this.bee.getPostageBatch(this.stamp), this.console)
-      this.console.divider()
     }
   }
 

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -50,12 +50,11 @@ export class Upload extends RootCommand implements LeafCommand {
   public skipSync!: boolean
 
   @Option({
-    key: 'keep-name',
+    key: 'drop-name',
     type: 'boolean',
-    description: 'Keep file name when upliading a single file',
-    default: true,
+    description: 'Erase file name when upliading a single file',
   })
-  public keepName!: boolean
+  public dropName!: boolean
 
   @Option({
     key: 'sync-polling-time',
@@ -194,7 +193,7 @@ export class Upload extends RootCommand implements LeafCommand {
   private async uploadSingleFile(postageBatchId: string, tag?: Tag): Promise<string> {
     const readable = FS.readFileSync(this.path)
     const parsedPath = parse(this.path)
-    this.hash = await this.bee.uploadFile(postageBatchId, readable, this.keepName ? parsedPath.base : undefined, {
+    this.hash = await this.bee.uploadFile(postageBatchId, readable, this.dropName ? undefined : parsedPath.base, {
       tag: tag && tag.uid,
       pin: this.pin,
     })

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -88,9 +88,7 @@ export class Upload extends RootCommand implements LeafCommand {
 
   public hash!: string
 
-  public usedFromOtherCommand = false
-
-  public async run(): Promise<void> {
+  public async run(usedFromOtherCommand = false): Promise<void> {
     this.initCommand()
 
     let url: string
@@ -162,7 +160,7 @@ export class Upload extends RootCommand implements LeafCommand {
     this.console.dim('Uploading was successful!')
     this.console.log(bold(`URL -> ${green(url)}`))
 
-    if (!this.usedFromOtherCommand) {
+    if (!usedFromOtherCommand) {
       this.console.quiet(this.hash)
       printEnrichedStamp(await this.bee.getPostageBatch(this.stamp), this.console)
       this.console.divider()

--- a/src/service/stamp/index.ts
+++ b/src/service/stamp/index.ts
@@ -64,3 +64,8 @@ export function printStamp(stamp: EnrichedStamp, console: CommandLog): void {
   console.verbose(bold('Immutable Flag: ') + stamp.immutableFlag)
   console.quiet(stamp.batchID + ' ' + stamp.usageText)
 }
+
+export function printEnrichedStamp(stamp: PostageBatch, console: CommandLog): void {
+  const enrichedStamp = enrichStamp(stamp)
+  printStamp(enrichedStamp, console)
+}

--- a/src/service/stamp/index.ts
+++ b/src/service/stamp/index.ts
@@ -1,4 +1,5 @@
 import { Bee, PostageBatch } from '@ethersphere/bee-js'
+import { bold } from 'kleur'
 import { exit } from 'process'
 import { CommandLog } from '../../command/root-command/command-log'
 import { EnrichedStamp } from './types/stamp'
@@ -48,4 +49,18 @@ export function enrichStamp(stamp: PostageBatch): EnrichedStamp {
     usageNormal,
     usageText,
   }
+}
+
+export function printStamp(stamp: EnrichedStamp, console: CommandLog): void {
+  console.divider('-')
+  console.log(bold('Stamp ID: ') + stamp.batchID)
+  console.log(bold('Usage: ') + stamp.usageText)
+  console.verbose(bold('Depth: ') + stamp.depth)
+  console.verbose(bold('Bucket depth: ') + stamp.bucketDepth)
+  console.verbose(bold('Amount: ') + stamp.amount)
+  console.verbose(bold('Usable: ') + stamp.usable)
+  console.verbose(bold('Utilization: ') + stamp.utilization)
+  console.verbose(bold('Block Number: ') + stamp.blockNumber)
+  console.verbose(bold('Immutable Flag: ') + stamp.immutableFlag)
+  console.quiet(stamp.batchID + ' ' + stamp.usageText)
 }

--- a/src/service/stamp/index.ts
+++ b/src/service/stamp/index.ts
@@ -32,14 +32,14 @@ export async function pickStamp(bee: Bee, console: CommandLog): Promise<string> 
   return hex
 }
 
-export function calculateUsagePercentage(stamp: PostageBatch): number {
+export function normalizeUtilization(stamp: PostageBatch): number {
   const { depth, bucketDepth, utilization } = stamp
 
   return utilization / Math.pow(2, depth - bucketDepth)
 }
 
 export function enrichStamp(stamp: PostageBatch): EnrichedStamp {
-  const usage = calculateUsagePercentage(stamp)
+  const usage = normalizeUtilization(stamp)
   const usageNormal = Math.ceil(usage * 100)
   const usageText = usageNormal + '%'
 

--- a/test/command/feed.spec.ts
+++ b/test/command/feed.spec.ts
@@ -5,7 +5,7 @@ import { getStampOption } from '../utility/stamp'
 
 describeCommand(
   'Test Feed command',
-  ({ consoleMessages, getLastMessage }) => {
+  ({ consoleMessages, getLastMessage, hasMessageContaining }) => {
     it('should upload file, update feed and print it', async () => {
       // create identity
       await invokeTestCli(['identity', 'create', 'test', '--password', 'test'])
@@ -79,9 +79,8 @@ describeCommand(
         hash,
         ...getStampOption(),
       ])
-      expect(consoleMessages).toHaveLength(1)
-      expect(consoleMessages[0]).toContain('Feed Manifest URL')
-      expect(consoleMessages[0]).toContain('/bzz/')
+      expect(hasMessageContaining('Feed Manifest URL')).toBeTruthy()
+      expect(hasMessageContaining('/bzz/')).toBeTruthy()
     })
   },
   { configFileName: 'feed' },

--- a/test/command/pinning.spec.ts
+++ b/test/command/pinning.spec.ts
@@ -77,8 +77,7 @@ describeCommand(
       const upload = invocation.runnable as Upload
       const { hash } = upload
       await invokeTestCli(['pinning', 'reupload', hash])
-      expect(consoleMessages).toHaveLength(4)
-      expect(consoleMessages[3]).toContain('Reuploaded successfully.')
+      expect(hasMessageContaining('Reuploaded successfully.')).toBeTruthy()
     })
 
     it('should allow reuploading pinned folder', async () => {
@@ -86,8 +85,7 @@ describeCommand(
       const upload = invocation.runnable as Upload
       const { hash } = upload
       await invokeTestCli(['pinning', 'reupload', hash])
-      expect(consoleMessages).toHaveLength(4)
-      expect(consoleMessages[3]).toContain('Reuploaded successfully.')
+      expect(hasMessageContaining('Reuploaded successfully.')).toBeTruthy()
     })
 
     it('should reupload all pinned content', async () => {

--- a/test/command/pinning.spec.ts
+++ b/test/command/pinning.spec.ts
@@ -12,31 +12,26 @@ async function uploadAndGetHash(path: string, indexDocument?: string): Promise<s
 
 describeCommand(
   'Test Pinning command',
-  ({ consoleMessages, getLastMessage }) => {
+  ({ consoleMessages, getLastMessage, hasMessageContaining }) => {
     it('should pin a collection with index.html index document', async () => {
       const hash = await uploadAndGetHash('test/testpage')
       expect(hash).toMatch(/[a-z0-9]{64}/)
       await invokeTestCli(['pinning', 'pin', hash])
-      expect(consoleMessages).toHaveLength(4)
-      expect(consoleMessages[3]).toBe('Pinned successfully')
+      expect(hasMessageContaining('Pinned successfully')).toBeTruthy()
     })
 
     it('should pin a collection with no index document', async () => {
       const hash = await uploadAndGetHash('test/command')
       expect(hash).toMatch(/[a-z0-9]{64}/)
       await invokeTestCli(['pinning', 'pin', hash])
-      expect(consoleMessages).toHaveLength(3)
-      const successMessage = consoleMessages[2]
-      expect(successMessage).toBe('Pinned successfully')
+      expect(hasMessageContaining('Pinned successfully')).toBeTruthy()
     })
 
     it('should pin a collection with explicit index document', async () => {
       const hash = await uploadAndGetHash('test/command', 'pinning.spec.ts')
       expect(hash).toMatch(/[a-z0-9]{64}/)
       await invokeTestCli(['pinning', 'pin', hash])
-      expect(consoleMessages).toHaveLength(3)
-      const successMessage = consoleMessages[2]
-      expect(successMessage).toBe('Pinned successfully')
+      expect(hasMessageContaining('Pinned successfully')).toBeTruthy()
     })
 
     it('should list less pinned items after unpinning', async () => {

--- a/test/command/upload.spec.ts
+++ b/test/command/upload.spec.ts
@@ -4,7 +4,7 @@ import type { Upload } from '../../src/command/upload'
 import { describeCommand, invokeTestCli } from '../utility'
 import { getStampOption } from '../utility/stamp'
 
-describeCommand('Test Upload command', ({ consoleMessages, getNthLastMessage }) => {
+describeCommand('Test Upload command', ({ consoleMessages, hasMessageContaining }) => {
   if (existsSync('test/data/8mb.bin')) {
     unlinkSync('test/data/8mb.bin')
   }
@@ -55,11 +55,11 @@ describeCommand('Test Upload command', ({ consoleMessages, getNthLastMessage }) 
 
   it('should not warn for large files with flag', async () => {
     await invokeTestCli(['upload', 'test/data/8mb.bin', '-v', '--size-check', 'false', ...getStampOption()])
-    expect(getNthLastMessage(2)).toContain('Uploading was successful!')
+    expect(hasMessageContaining('Uploading was successful!')).toBeTruthy()
   })
 
   it('should not warn for large folders with flag', async () => {
     await invokeTestCli(['upload', 'test/data', '-v', '--size-check', 'false', ...getStampOption()])
-    expect(getNthLastMessage(2)).toContain('Uploading was successful!')
+    expect(hasMessageContaining('Uploading was successful!')).toBeTruthy()
   })
 })

--- a/test/utility/index.ts
+++ b/test/utility/index.ts
@@ -18,6 +18,7 @@ type describeFunctionArgs = {
   configFolderPath: string
   getNthLastMessage: (n: number) => string
   getLastMessage: () => string
+  hasMessageContaining: (substring: string) => boolean
 }
 
 export function describeCommand(
@@ -30,6 +31,8 @@ export function describeCommand(
     const configFileName = options?.configFileName
     const getNthLastMessage = (n: number) => consoleMessages[consoleMessages.length - n]
     const getLastMessage = () => consoleMessages[consoleMessages.length - 1]
+    const hasMessageContaining = (substring: string) =>
+      Boolean(consoleMessages.find(consoleMessage => consoleMessage.includes(substring)))
     const configFolderPath = join(__dirname, '..', 'testconfig')
 
     //set config environment variable
@@ -72,6 +75,6 @@ export function describeCommand(
       consoleMessages.length = 0
     })
 
-    func({ consoleMessages, getNthLastMessage, getLastMessage, configFolderPath })
+    func({ consoleMessages, getNthLastMessage, getLastMessage, hasMessageContaining, configFolderPath })
   })
 }


### PR DESCRIPTION
* Adds `--drop-name` flag to erase file name during upload
* Print stamp usage after `upload`, `feed print` and `feed upload`
* Change upload bar from `processed` to `synced` which works when reading file to memory