### PR TITLE
fix(cashout): set minimum of minimum to 1

### DIFF
--- a/src/command/cheque/cashout.ts
+++ b/src/command/cheque/cashout.ts
@@ -28,9 +28,9 @@ export class Cashout extends ChequeCommand implements LeafCommand {
     key: 'minimum',
     alias: 'm',
     type: 'bigint',
-    minimum: BigInt(0),
+    minimum: BigInt(1),
     description: 'Cashout cheques with balance above this value in PLUR',
-    default: BigInt(0),
+    default: BigInt(1),
   })
   public minimum!: bigint
 


### PR DESCRIPTION
Otherwise transactions were created for cashing out zero valued cheques.

I couldn't really test this, so take it more as a suggestion than a well-tested PR.