### PR TITLE
feat: rework --skip-sync to --sync with connectivity check

### DIFF
--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -46,7 +46,7 @@ export class Upload extends RootCommand implements LeafCommand {
   @Option({
     key: 'sync',
     type: 'boolean',
-    description: 'Waiting for chunk synchronization over the network',
+    description: 'Wait for chunk synchronization over the network',
   })
   public sync!: boolean
 

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -92,11 +92,11 @@ export class Upload extends RootCommand implements LeafCommand {
   public async run(usedFromOtherCommand = false): Promise<void> {
     this.initCommand()
 
-    await this.handleSyncSupport()
-
     if (this.hasUnsupportedGatewayOptions()) {
       exit(1)
     }
+
+    await this.handleSyncSupport()
 
     let url: string
     let tag: Tag | undefined

--- a/src/command/upload.ts
+++ b/src/command/upload.ts
@@ -96,7 +96,7 @@ export class Upload extends RootCommand implements LeafCommand {
       exit(1)
     }
 
-    await this.handleSyncSupport()
+    await this.maybePrintSyncWarning()
 
     let url: string
     let tag: Tag | undefined
@@ -320,7 +320,7 @@ export class Upload extends RootCommand implements LeafCommand {
     return false
   }
 
-  private async handleSyncSupport(): Promise<void | never> {
+  private async maybePrintSyncWarning(): Promise<void> {
     if (this.quiet || !this.sync) {
       return
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,9 @@ export const beeApiUrl: IOption<string> = {
   default: 'http://localhost:1633',
   description: 'URL of the Bee-client API',
   envKey: 'BEE_API_URL',
+  required: {
+    when: 'bee-debug-api-url',
+  },
 }
 
 export const beeDebugApiUrl: IOption<string> = {
@@ -22,6 +25,9 @@ export const beeDebugApiUrl: IOption<string> = {
   default: 'http://localhost:1635',
   description: 'URL of the Bee-client Debug API',
   envKey: 'BEE_DEBUG_API_URL',
+  required: {
+    when: 'bee-api-url',
+  },
 }
 
 export const configFolder: IOption<string> = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,9 +15,6 @@ export const beeApiUrl: IOption<string> = {
   default: 'http://localhost:1633',
   description: 'URL of the Bee-client API',
   envKey: 'BEE_API_URL',
-  required: {
-    when: 'bee-debug-api-url',
-  },
 }
 
 export const beeDebugApiUrl: IOption<string> = {
@@ -25,9 +22,6 @@ export const beeDebugApiUrl: IOption<string> = {
   default: 'http://localhost:1635',
   description: 'URL of the Bee-client Debug API',
   envKey: 'BEE_DEBUG_API_URL',
-  required: {
-    when: 'bee-api-url',
-  },
 }
 
 export const configFolder: IOption<string> = {

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -9,6 +9,14 @@ function deleteWholeRow(): string {
   return '\u001b[2K'
 }
 
+export function warningSymbol(): string {
+  return chalk.yellow.bold('⚠️  Warning!')
+}
+
+export function warningText(string: string): string {
+  return chalk.yellow(string)
+}
+
 export function deletePreviousLine(): void {
   process.stdout.write('\r' + goUpOneRow() + deleteWholeRow())
 }

--- a/test/command/feed.spec.ts
+++ b/test/command/feed.spec.ts
@@ -62,7 +62,7 @@ describeCommand(
 
     it('should update feeds', async () => {
       await invokeTestCli(['identity', 'create', 'update-feed-test', '-P', '1234', '-v'])
-      const uploadCommand = await invokeTestCli(['upload', 'README.md', '--skip-sync', ...getStampOption()])
+      const uploadCommand = await invokeTestCli(['upload', 'README.md', ...getStampOption()])
       const upload = uploadCommand.runnable as Upload
       const { hash } = upload
       consoleMessages.length = 0

--- a/test/command/pinning.spec.ts
+++ b/test/command/pinning.spec.ts
@@ -81,7 +81,7 @@ describeCommand(
     })
 
     it('should allow reuploading pinned folder', async () => {
-      const invocation = await invokeTestCli(['upload', 'test', '--pin', ...getStampOption()])
+      const invocation = await invokeTestCli(['upload', 'test', '--pin', '--size-check', 'false', ...getStampOption()])
       const upload = invocation.runnable as Upload
       const { hash } = upload
       await invokeTestCli(['pinning', 'reupload', hash])

--- a/test/command/upload.spec.ts
+++ b/test/command/upload.spec.ts
@@ -111,4 +111,14 @@ describeCommand('Test Upload command', ({ consoleMessages, hasMessageContaining 
     ])
     expect(hasMessageContaining('does not support syncing')).toBeTruthy()
   })
+
+  it('should succeed with --sync', async () => {
+    await invokeTestCli(['upload', 'README.md', '--sync', '-v', ...getStampOption()])
+    expect(hasMessageContaining('Uploading was successful!')).toBeTruthy()
+  })
+
+  it('should succeed with --sync and --encrypt', async () => {
+    await invokeTestCli(['upload', 'README.md', '--sync', '--encrypt', '-v', ...getStampOption()])
+    expect(hasMessageContaining('Uploading was successful!')).toBeTruthy()
+  })
 })

--- a/test/command/upload.spec.ts
+++ b/test/command/upload.spec.ts
@@ -79,7 +79,6 @@ describeCommand('Test Upload command', ({ consoleMessages, hasMessageContaining 
     await invokeTestCli([
       'upload',
       'README.md',
-      '--skip-sync',
       '--bee-api-url',
       'http://gateway.ethswarm.org',
       '--encrypt',
@@ -92,7 +91,6 @@ describeCommand('Test Upload command', ({ consoleMessages, hasMessageContaining 
     await invokeTestCli([
       'upload',
       'README.md',
-      '--skip-sync',
       '--bee-api-url',
       'http://gateway.ethswarm.org',
       '--pin',
@@ -105,6 +103,7 @@ describeCommand('Test Upload command', ({ consoleMessages, hasMessageContaining 
     await invokeTestCli([
       'upload',
       'README.md',
+      '--sync',
       '--bee-api-url',
       'http://gateway.ethswarm.org',
       '--encrypt',

--- a/test/misc/curl.spec.ts
+++ b/test/misc/curl.spec.ts
@@ -7,7 +7,6 @@ describeCommand('--curl flag', ({ consoleMessages }) => {
     expect(consoleMessages[0]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
     expect(consoleMessages[0]).toContain(`-H "swarm-postage-batch-id: ${getStampOption()[1]}`)
     expect(consoleMessages[0]).toContain('-H "content-length: 220"')
-    expect(consoleMessages[0]).toContain('-H "swarm-tag: ')
     expect(consoleMessages[0]).not.toContain('swarm-encrypt')
   })
 
@@ -16,7 +15,6 @@ describeCommand('--curl flag', ({ consoleMessages }) => {
     expect(consoleMessages[0]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
     expect(consoleMessages[0]).toContain(`-H "swarm-postage-batch-id: ${getStampOption()[1]}`)
     expect(consoleMessages[0]).toContain('-H "content-length: 220"')
-    expect(consoleMessages[0]).toContain('-H "swarm-tag: ')
     expect(consoleMessages[0]).toContain('-H "swarm-encrypt: true"')
   })
 

--- a/test/misc/curl.spec.ts
+++ b/test/misc/curl.spec.ts
@@ -4,39 +4,39 @@ import { getStampOption } from '../utility/stamp'
 describeCommand('--curl flag', ({ consoleMessages }) => {
   it('should print upload command without encryption', async () => {
     await invokeTestCli(['upload', 'test/testpage/index.html', '--curl', ...getStampOption()])
-    expect(consoleMessages[0]).toContain('curl -X POST http://localhost:1633/tags ')
-    expect(consoleMessages[1]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
-    expect(consoleMessages[1]).toContain(`-H "swarm-postage-batch-id: ${getStampOption()[1]}`)
-    expect(consoleMessages[1]).toContain('-H "content-length: 220"')
-    expect(consoleMessages[1]).toContain('-H "swarm-tag: ')
-    expect(consoleMessages[1]).not.toContain('swarm-encrypt')
+    expect(consoleMessages[1]).toContain('curl -X POST http://localhost:1633/tags ')
+    expect(consoleMessages[2]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
+    expect(consoleMessages[2]).toContain(`-H "swarm-postage-batch-id: ${getStampOption()[1]}`)
+    expect(consoleMessages[2]).toContain('-H "content-length: 220"')
+    expect(consoleMessages[2]).toContain('-H "swarm-tag: ')
+    expect(consoleMessages[2]).not.toContain('swarm-encrypt')
   })
 
   it('should print upload command with encryption', async () => {
     await invokeTestCli(['upload', 'test/testpage/index.html', '--encrypt', '--curl', ...getStampOption()])
-    expect(consoleMessages[0]).toContain('curl -X POST http://localhost:1633/tags ')
-    expect(consoleMessages[1]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
-    expect(consoleMessages[1]).toContain(`-H "swarm-postage-batch-id: ${getStampOption()[1]}`)
-    expect(consoleMessages[1]).toContain('-H "content-length: 220"')
-    expect(consoleMessages[1]).toContain('-H "swarm-tag: ')
-    expect(consoleMessages[1]).toContain('-H "swarm-encrypt: true"')
+    expect(consoleMessages[1]).toContain('curl -X POST http://localhost:1633/tags ')
+    expect(consoleMessages[2]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
+    expect(consoleMessages[2]).toContain(`-H "swarm-postage-batch-id: ${getStampOption()[1]}`)
+    expect(consoleMessages[2]).toContain('-H "content-length: 220"')
+    expect(consoleMessages[2]).toContain('-H "swarm-tag: ')
+    expect(consoleMessages[2]).toContain('-H "swarm-encrypt: true"')
   })
 
   it('should print <stream> for files', async () => {
     await invokeTestCli(['upload', 'test/testpage/index.html', '--curl', ...getStampOption()])
-    expect(consoleMessages[1]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
-    expect(consoleMessages[1]).toContain('--data "<stream>"')
+    expect(consoleMessages[2]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
+    expect(consoleMessages[2]).toContain('--data "<stream>"')
   })
 
   it('should print <buffer> for directories', async () => {
     await invokeTestCli(['upload', 'test/testpage/', '--curl', ...getStampOption()])
-    expect(consoleMessages[2]).toContain('curl -X POST http://localhost:1633/bzz ')
-    expect(consoleMessages[2]).toContain('--data "<buffer>"')
+    expect(consoleMessages[3]).toContain('curl -X POST http://localhost:1633/bzz ')
+    expect(consoleMessages[3]).toContain('--data "<buffer>"')
   })
 
   it('should not print undefined params', async () => {
     await invokeTestCli(['upload', 'test/testpage/index.html', '--curl', '--drop-name', ...getStampOption()])
-    expect(consoleMessages[1]).toContain('curl -X POST http://localhost:1633/bzz ')
-    expect(consoleMessages[1]).toContain('--data "<stream>"')
+    expect(consoleMessages[2]).toContain('curl -X POST http://localhost:1633/bzz ')
+    expect(consoleMessages[2]).toContain('--data "<stream>"')
   })
 })

--- a/test/misc/curl.spec.ts
+++ b/test/misc/curl.spec.ts
@@ -4,39 +4,37 @@ import { getStampOption } from '../utility/stamp'
 describeCommand('--curl flag', ({ consoleMessages }) => {
   it('should print upload command without encryption', async () => {
     await invokeTestCli(['upload', 'test/testpage/index.html', '--curl', ...getStampOption()])
-    expect(consoleMessages[1]).toContain('curl -X POST http://localhost:1633/tags ')
-    expect(consoleMessages[2]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
-    expect(consoleMessages[2]).toContain(`-H "swarm-postage-batch-id: ${getStampOption()[1]}`)
-    expect(consoleMessages[2]).toContain('-H "content-length: 220"')
-    expect(consoleMessages[2]).toContain('-H "swarm-tag: ')
-    expect(consoleMessages[2]).not.toContain('swarm-encrypt')
+    expect(consoleMessages[0]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
+    expect(consoleMessages[0]).toContain(`-H "swarm-postage-batch-id: ${getStampOption()[1]}`)
+    expect(consoleMessages[0]).toContain('-H "content-length: 220"')
+    expect(consoleMessages[0]).toContain('-H "swarm-tag: ')
+    expect(consoleMessages[0]).not.toContain('swarm-encrypt')
   })
 
   it('should print upload command with encryption', async () => {
     await invokeTestCli(['upload', 'test/testpage/index.html', '--encrypt', '--curl', ...getStampOption()])
-    expect(consoleMessages[1]).toContain('curl -X POST http://localhost:1633/tags ')
-    expect(consoleMessages[2]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
-    expect(consoleMessages[2]).toContain(`-H "swarm-postage-batch-id: ${getStampOption()[1]}`)
-    expect(consoleMessages[2]).toContain('-H "content-length: 220"')
-    expect(consoleMessages[2]).toContain('-H "swarm-tag: ')
-    expect(consoleMessages[2]).toContain('-H "swarm-encrypt: true"')
+    expect(consoleMessages[0]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
+    expect(consoleMessages[0]).toContain(`-H "swarm-postage-batch-id: ${getStampOption()[1]}`)
+    expect(consoleMessages[0]).toContain('-H "content-length: 220"')
+    expect(consoleMessages[0]).toContain('-H "swarm-tag: ')
+    expect(consoleMessages[0]).toContain('-H "swarm-encrypt: true"')
   })
 
   it('should print <stream> for files', async () => {
     await invokeTestCli(['upload', 'test/testpage/index.html', '--curl', ...getStampOption()])
-    expect(consoleMessages[2]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
-    expect(consoleMessages[2]).toContain('--data "<stream>"')
+    expect(consoleMessages[0]).toContain('curl -X POST http://localhost:1633/bzz?name=index.html ')
+    expect(consoleMessages[0]).toContain('--data "<stream>"')
   })
 
   it('should print <buffer> for directories', async () => {
     await invokeTestCli(['upload', 'test/testpage/', '--curl', ...getStampOption()])
-    expect(consoleMessages[3]).toContain('curl -X POST http://localhost:1633/bzz ')
-    expect(consoleMessages[3]).toContain('--data "<buffer>"')
+    expect(consoleMessages[0]).toContain('curl -X POST http://localhost:1633/bzz ')
+    expect(consoleMessages[0]).toContain('--data "<buffer>"')
   })
 
   it('should not print undefined params', async () => {
     await invokeTestCli(['upload', 'test/testpage/index.html', '--curl', '--drop-name', ...getStampOption()])
-    expect(consoleMessages[2]).toContain('curl -X POST http://localhost:1633/bzz ')
-    expect(consoleMessages[2]).toContain('--data "<stream>"')
+    expect(consoleMessages[0]).toContain('curl -X POST http://localhost:1633/bzz ')
+    expect(consoleMessages[0]).toContain('--data "<stream>"')
   })
 })

--- a/test/misc/curl.spec.ts
+++ b/test/misc/curl.spec.ts
@@ -28,8 +28,8 @@ describeCommand('--curl flag', ({ consoleMessages }) => {
 
   it('should print <buffer> for directories', async () => {
     await invokeTestCli(['upload', 'test/testpage/', '--curl', ...getStampOption()])
-    expect(consoleMessages[0]).toContain('curl -X POST http://localhost:1633/bzz ')
-    expect(consoleMessages[0]).toContain('--data "<buffer>"')
+    expect(consoleMessages[1]).toContain('curl -X POST http://localhost:1633/bzz ')
+    expect(consoleMessages[1]).toContain('--data "<buffer>"')
   })
 
   it('should not print undefined params', async () => {


### PR DESCRIPTION
Removed `--skip-sync`, added `--sync`, and `--sync` is now opt-in

---

When debug API is not available:

![image](https://user-images.githubusercontent.com/77121044/127448348-8aa793c7-7fc5-47d3-abf4-226eaa901af9.png)

---

When there are no connected peers:

![image](https://user-images.githubusercontent.com/77121044/127448477-3e43a77b-0e20-48d9-a581-ae31b7c4514e.png)

---

Prompts have been removed, only a warning message is displayed.