### PR TITLE
fix: convert TTL to human readable format

### DIFF
--- a/src/service/stamp/index.ts
+++ b/src/service/stamp/index.ts
@@ -1,6 +1,7 @@
 import { BeeDebug, PostageBatch } from '@ethersphere/bee-js'
 import { exit } from 'process'
 import { CommandLog } from '../../command/root-command/command-log'
+import { secondsToDhms } from '../../utils'
 import { createKeyValue } from '../../utils/text'
 import { EnrichedStamp } from './types/stamp'
 
@@ -52,7 +53,7 @@ export function printStamp(stamp: EnrichedStamp, console: CommandLog, printUsage
   console.log(createKeyValue('Stamp ID', stamp.batchID))
   console.log(createKeyValue('Label', stamp.label))
   console.log(createKeyValue('Usage', stamp.usageText))
-  console.log(createKeyValue('TTL', stamp.batchTTL === -1 ? 'unknown' : stamp.batchTTL + ' seconds'))
+  console.log(createKeyValue('TTL', stamp.batchTTL === -1 ? 'unknown' : secondsToDhms(stamp.batchTTL)))
   console.verbose(createKeyValue('Depth', stamp.depth))
   console.verbose(createKeyValue('Bucket Depth', stamp.bucketDepth))
   console.verbose(createKeyValue('Amount', stamp.amount))

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,6 +51,20 @@ export function getByteSize(data: string | Uint8Array): number {
   return Buffer.byteLength(data, 'utf-8')
 }
 
+export function secondsToDhms(secs: number): string {
+  const d = Math.floor(secs / (3600 * 24))
+  const h = Math.floor((secs % (3600 * 24)) / 3600)
+  const m = Math.floor((secs % 3600) / 60)
+  const s = Math.floor(secs % 60)
+
+  const dDisplay = d > 0 ? d + (d === 1 ? ' day, ' : ' days, ') : ''
+  const hDisplay = h > 0 ? h + (h === 1 ? ' hour, ' : ' hours, ') : ''
+  const mDisplay = m > 0 ? m + (m === 1 ? ' minute, ' : ' minutes, ') : ''
+  const sDisplay = s > 0 ? s + (s === 1 ? ' second' : ' seconds') : ''
+
+  return dDisplay + hDisplay + mDisplay + sDisplay
+}
+
 /**
  * Lists all files recursively in a folder
  * @param path folder path


### PR DESCRIPTION
Referring issue
#355 

![image](https://user-images.githubusercontent.com/1278025/184721807-8faf2854-a760-4a95-b7e3-ce7fd887c408.png)

Added a util method to convert seconds to time human-readable format DHMS