### PR TITLE
fix: manifest commands

### DIFF
--- a/src/command/manifest/index.ts
+++ b/src/command/manifest/index.ts
@@ -1,10 +1,15 @@
 import { GroupCommand } from 'furious-commander'
+import { Add } from './add'
+import { Create } from './create'
 import { Download } from './download'
 import { List } from './list'
+import { Merge } from './merge'
+import { Remove } from './remove'
+import { Sync } from './sync'
 
 export class Manifest implements GroupCommand {
   public readonly name = 'manifest'
   public readonly description = 'Operate on manifests'
 
-  public subCommandClasses = [Download, List]
+  public subCommandClasses = [Add, Create, Download, List, Merge, Remove, Sync]
 }


### PR DESCRIPTION
Enables all manifest commands and fixes unintentional file deletion by prompting user to confirm.

Closes #253 