### PR TITLE
feat: add --dev global option

### DIFF
--- a/src/command/root-command/index.ts
+++ b/src/command/root-command/index.ts
@@ -1,4 +1,4 @@
-import { Bee, BeeOptions, Reference } from '@upcoming/bee-js'
+import { Bee, BeeDev, BeeOptions, Reference } from '@upcoming/bee-js'
 import { Optional } from 'cafe-utility'
 import { ExternalOption, Sourcemap, Utils } from 'furious-commander'
 import { printCurlCommand } from '../../curl'
@@ -35,6 +35,9 @@ export class RootCommand {
   @ExternalOption('yes')
   public yes!: boolean
 
+  @ExternalOption('dev')
+  public dev!: boolean
+
   public bee!: Bee
 
   public console!: CommandLog
@@ -67,7 +70,7 @@ export class RootCommand {
     if (this.header.length) {
       beeOptions.headers = parseHeaders(this.header)
     }
-    this.bee = new Bee(this.beeApiUrl, beeOptions)
+    this.bee = this.dev ? new BeeDev(this.beeApiUrl, beeOptions) : new Bee(this.beeApiUrl, beeOptions)
     this.verbosity = VerbosityLevel.Normal
 
     if (this.quiet) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,6 +91,13 @@ export const yes: IOption<string[]> = {
   description: 'Agree to all prompts',
 }
 
+export const dev: IOption<boolean> = {
+  key: 'dev',
+  description: 'Indicate that the connected Bee node is running in dev mode',
+  type: 'boolean',
+  default: false,
+}
+
 export const optionParameters: IOption<unknown>[] = [
   beeApiUrl,
   configFolder,
@@ -102,6 +109,7 @@ export const optionParameters: IOption<unknown>[] = [
   curl,
   header,
   yes,
+  dev,
 ]
 
 export const rootCommandClasses = [


### PR DESCRIPTION
`--dev` global option indicate that the connected Bee node is running in dev mode.